### PR TITLE
chore(github): Use dedicated env for router-api

### DIFF
--- a/.github/workflows/router-api-prod.yml
+++ b/.github/workflows/router-api-prod.yml
@@ -14,7 +14,7 @@ jobs:
       contents: read
       deployments: write
     environment:
-      name: Production
+      name: router-api-prod
       url: https://router.risedle.com
     name: Deploy
     steps:

--- a/.github/workflows/router-api-stag.yml
+++ b/.github/workflows/router-api-stag.yml
@@ -14,7 +14,7 @@ jobs:
       contents: read
       deployments: write
     environment:
-      name: Staging
+      name: router-api-stag
       url: https://router-staging.risedle.com
     name: Deploy
     steps:


### PR DESCRIPTION
Use dedicated github environment for `router-api`.

Learn more about github environment [here](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment) 