### PR TITLE
feat(router-api): Support /v1/:chainId/dexs

### DIFF
--- a/apps/router-api/src/chains.ts
+++ b/apps/router-api/src/chains.ts
@@ -1,7 +1,30 @@
-// Enum to keeptrack supported chains
 enum Chain {
     Mainnet = 1,
     Arbitrum = 42161,
 }
 
-export { Chain };
+interface DEX {
+    name: string;
+}
+
+const uniswapV2: DEX = {
+    name: "Uniswap V2",
+};
+
+const sushiswap: DEX = {
+    name: "Sushiswap",
+};
+
+const curveV1: DEX = {
+    name: "Curve V1",
+};
+
+const dexs = {};
+dexs[Chain.Mainnet] = [uniswapV2, sushiswap, curveV1];
+dexs[Chain.Arbitrum] = [sushiswap, curveV1];
+
+function getSupportedDexs(chainId: string): Array<DEX> {
+    return dexs[chainId];
+}
+
+export { Chain, getSupportedDexs };

--- a/apps/router-api/src/index.ts
+++ b/apps/router-api/src/index.ts
@@ -1,6 +1,6 @@
 import { Router } from "itty-router";
 import { error, json, missing } from "itty-router-extras";
-import { Chain } from "./chains";
+import { Chain, getSupportedDexs } from "./chains";
 
 // Create parent router
 const router = Router();
@@ -14,6 +14,16 @@ v1.get("/chains", async () => {
     return json({
         chains: Object.values(Chain).filter((v) => !isNaN(Number(v))),
     });
+});
+
+// GET /v1/:chainID/dexs
+v1.get("/:chainId/dexs", async ({ params }) => {
+    const chainId: string = params.chainId;
+    if (!(chainId in Chain)) {
+        return missing({ message: "Chain not supported" });
+    }
+    const dexs = getSupportedDexs(chainId);
+    return json({ chain: Chain[chainId], dexs: dexs });
 });
 
 // Base router

--- a/apps/router-api/test/dexes.spec.ts
+++ b/apps/router-api/test/dexes.spec.ts
@@ -1,0 +1,62 @@
+import { worker } from "@/index";
+
+describe("Given Invalid Chain", () => {
+    it("should respond 404 Not Found", async () => {
+        const env = getMiniflareBindings();
+        const res = await worker.fetch(
+            new Request("http://localhost/v1/2000/dexs"),
+            env
+        );
+        expect(res.status).toBe(404);
+        expect(await res.json()).toEqual({
+            message: "Chain not supported",
+        });
+    });
+});
+
+describe("Given Mainnet", () => {
+    it("should responds correct dexs", async () => {
+        const env = getMiniflareBindings();
+        const res = await worker.fetch(
+            new Request("http://localhost/v1/1/dexs"),
+            env
+        );
+        expect(res.status).toBe(200);
+        expect(await res.json()).toEqual({
+            chain: "Mainnet",
+            dexs: [
+                {
+                    name: "Uniswap V2",
+                },
+                {
+                    name: "Sushiswap",
+                },
+                {
+                    name: "Curve V1",
+                },
+            ],
+        });
+    });
+});
+
+describe("Given Arbitrum", () => {
+    it("should responds correct dexs", async () => {
+        const env = getMiniflareBindings();
+        const res = await worker.fetch(
+            new Request("http://localhost/v1/42161/dexs"),
+            env
+        );
+        expect(res.status).toBe(200);
+        expect(await res.json()).toEqual({
+            chain: "Arbitrum",
+            dexs: [
+                {
+                    name: "Sushiswap",
+                },
+                {
+                    name: "Curve V1",
+                },
+            ],
+        });
+    });
+});


### PR DESCRIPTION
Implement `GET /v1/:chainId/dexs`

It returns list of supported decentralized exchanges.

Fix RIS-219