### PR TITLE
feat(@risedle/types): setup automatic publish to npm

### DIFF
--- a/.github/workflows/risedle-types-release.yml
+++ b/.github/workflows/risedle-types-release.yml
@@ -1,0 +1,40 @@
+name: "@risedle/types"
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "packages/types/**"
+      - ".github/workflows/risedle-types-release.yml"
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v3
+        with:
+          node-version: "17.8.0"
+          cache: "npm"
+      - name: Install dependencies
+        run: npm install
+      - name: Build
+        run: npm run build
+        working-directory: ./packages/types
+      - name: Set access to public
+        run: npm config set access public
+        working-directory: ./packages/types
+      - name: Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GIT_AUTHOR_NAME: Risedle
+          GIT_AUTHOR_EMAIL: github@risedle.com
+          GIT_COMMITTER_NAME: Risedle
+          GIT_COMMITTER_EMAIL: github@risedle.com
+        run: npx semantic-release
+        working-directory: ./packages/types

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -1,0 +1,13 @@
+## @risedle/types
+
+Type definitions used across Risedle apps and packages.
+
+### Installation
+
+```sh
+npm install --save-exact @risedle/types@latest
+```
+
+### Usage
+
+Docs coming soon

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,0 +1,79 @@
+{
+    "name": "@risedle/types",
+    "version": "1.0.0",
+    "license": "MIT",
+    "source": "src/index.ts",
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "files": [
+        "dist",
+        "README.md"
+    ],
+    "scripts": {
+        "clean": "rm -rf dist",
+        "build": "tsc",
+        "lint": "eslint src/*.ts"
+    },
+    "prepublish": "tsc",
+    "homepage": "https://risedle.com",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/risedle/monorepo.git"
+    },
+    "bugs": {
+        "url": "https://github.com/risedle/monorepo/issues"
+    },
+    "author": {
+        "name": "bayu",
+        "email": "bayu@risedle.com",
+        "url": "https://github.com/pyk"
+    },
+    "contributors": [],
+    "devDependencies": {
+        "@semantic-release/git": "10.0.1",
+        "semantic-release": "19.0.3"
+    },
+    "release": {
+        "tagFormat": "@risedle/types-v${version}",
+        "branches": [
+            "main"
+        ],
+        "plugins": [
+            [
+                "@semantic-release/commit-analyzer",
+                {
+                    "preset": "conventionalcommits",
+                    "releaseRules": [
+                        {
+                            "scope": "!*@risedle/types*",
+                            "release": false
+                        }
+                    ]
+                }
+            ],
+            "@semantic-release/release-notes-generator",
+            "@semantic-release/npm",
+            [
+                "@semantic-release/github",
+                {
+                    "successComment": false,
+                    "failedComment": false,
+                    "assets": [
+                        {
+                            "path": "*.tgz",
+                            "label": "@risedle/types"
+                        }
+                    ],
+                    "labels": false
+                }
+            ],
+            [
+                "@semantic-release/git",
+                {
+                    "message": "chore(release): @risedle/types ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+                }
+            ]
+        ]
+    },
+    "dependencies": {}
+}

--- a/packages/types/src/chain.ts
+++ b/packages/types/src/chain.ts
@@ -1,0 +1,12 @@
+// Chain IDs
+export enum ChainId {
+    BSC = 56,
+    BSC_TESTNET = 97,
+}
+
+export interface Chain {
+    id: ChainId;
+    name: string;
+    symbol: string;
+    currency: string;
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./chain";
+export * from "./token";

--- a/packages/types/src/token.ts
+++ b/packages/types/src/token.ts
@@ -1,0 +1,18 @@
+import { ChainId } from "./chain";
+
+export interface Token {
+    name: string;
+    symbol: string;
+    decimals: number;
+    address: Map<ChainId, string>;
+}
+
+export interface TokenTradingInfo {
+    token: Token;
+    priceUSD: number;
+    dailyPriceChangeUSD: number;
+    dailyPriceChangePercentage: number;
+    volumeUSD: number;
+    dailyVolumeChangeUSD: number;
+    dailyVolumeChangePercentage: number;
+}

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "extends": "tsconfig/base.json",
+    "compilerOptions": {
+        "outDir": "dist"
+    },
+    "include": ["src/**/*.ts"],
+    "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
`@risedle/types` is home of all type definitions used across Risedle apps and packages