### PR TITLE
fix(@risedle/types): enable clean submodule import

### DIFF
--- a/.github/workflows/risedle-types-release.yml
+++ b/.github/workflows/risedle-types-release.yml
@@ -28,9 +28,6 @@ jobs:
       - name: Set access to public
         run: npm config set access public
         working-directory: ./packages/types
-      - name: Copy package.json
-        run: cp package.json dist/package.json
-        working-directory: ./packages/types
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -37,7 +37,21 @@
     "commitlint": {
         "extends": [
             "@commitlint/config-conventional"
-        ]
+        ],
+        "rules": {
+            "type-enum": [
+                2,
+                "always",
+                [
+                    "chore",
+                    "docs",
+                    "feat",
+                    "fix",
+                    "refactor",
+                    "bump"
+                ]
+            ]
+        }
     },
     "lint-staged": {
         "*.md": "prettier --write",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -2,9 +2,9 @@
     "name": "@risedle/types",
     "version": "1.0.0",
     "license": "MIT",
-    "source": "index.ts",
-    "main": "index.js",
-    "types": "index.d.ts",
+    "source": "src/index.ts",
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
     "files": [
         "dist",
         "README.md"
@@ -55,7 +55,6 @@
             [
                 "@semantic-release/npm",
                 {
-                    "pkgRoot": "./dist/",
                     "tarballDir": "."
                 }
             ],
@@ -81,5 +80,8 @@
             ]
         ]
     },
-    "dependencies": {}
+    "dependencies": {},
+    "exports": {
+        "./*": "./dist/*.js"
+    }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -47,11 +47,19 @@
                         {
                             "scope": "!*@risedle/types*",
                             "release": false
+                        },
+                        {
+                            "breaking": true,
+                            "release": false
+                        },
+                        {
+                            "scope": "@risedle/types",
+                            "type": "bump",
+                            "release": "major"
                         }
                     ]
                 }
             ],
-            "@semantic-release/release-notes-generator",
             [
                 "@semantic-release/npm",
                 {


### PR DESCRIPTION
Enable clean submodule import such as:

```typescript
import { ChainId } from "@risedle/types/chain";
```

Previously:

```typescript
import { ChainId } from "@risedle/types/dist/chain";
```

We use [subpath export](https://stackoverflow.com/a/69104582).

