### PR TITLE
fix(@risedle/chains): export index

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31106,20 +31106,15 @@
         },
         "packages/chains": {
             "name": "@risedle/chains",
-            "version": "1.0.0",
+            "version": "1.1.0",
             "license": "MIT",
             "dependencies": {
-                "@risedle/types": "1.0.2"
+                "@risedle/types": "1.1.1"
             },
             "devDependencies": {
                 "@semantic-release/git": "10.0.1",
                 "semantic-release": "19.0.3"
             }
-        },
-        "packages/chains/node_modules/@risedle/types": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@risedle/types/-/types-1.0.2.tgz",
-            "integrity": "sha512-AoWxaB+ZyKcVfogBstcygtfEwhsUu/ibxs7aOIEm12WO4IXvZyXLMFTfovwY4U4lbRmnKz26RhK5ivP7jGn4gA=="
         },
         "packages/eslint-config-custom": {
             "version": "0.0.0",
@@ -31147,7 +31142,7 @@
         },
         "packages/types": {
             "name": "@risedle/types",
-            "version": "1.0.0",
+            "version": "1.1.1",
             "license": "MIT",
             "devDependencies": {
                 "@semantic-release/git": "10.0.1",
@@ -34832,16 +34827,9 @@
         "@risedle/chains": {
             "version": "file:packages/chains",
             "requires": {
-                "@risedle/types": "1.0.2",
+                "@risedle/types": "1.1.1",
                 "@semantic-release/git": "10.0.1",
                 "semantic-release": "19.0.3"
-            },
-            "dependencies": {
-                "@risedle/types": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/@risedle/types/-/types-1.0.2.tgz",
-                    "integrity": "sha512-AoWxaB+ZyKcVfogBstcygtfEwhsUu/ibxs7aOIEm12WO4IXvZyXLMFTfovwY4U4lbRmnKz26RhK5ivP7jGn4gA=="
-                }
             }
         },
         "@risedle/quotes": {

--- a/packages/chains/README.md
+++ b/packages/chains/README.md
@@ -1,5 +1,7 @@
 ## @risedle/chains
 
+List of supported chains and its utility functions to interact with the chain.
+
 ### Installation
 
 ```sh
@@ -8,9 +10,11 @@ npm install @risedle/chains@latest --save-exact
 
 ### Usage
 
-Docs coming soon
+You can use `@risedle/chains` like the following:
 
-bump
+```typescript
+import { Binance } from "@risedle/chains";
+```
 
 ### Upgrading types
 

--- a/packages/chains/package.json
+++ b/packages/chains/package.json
@@ -93,6 +93,7 @@
         "@risedle/types": "1.1.1"
     },
     "exports": {
+        ".": "./dist/index.js",
         "./*": "./dist/*.js"
     }
 }

--- a/packages/chains/package.json
+++ b/packages/chains/package.json
@@ -90,7 +90,7 @@
         ]
     },
     "dependencies": {
-        "@risedle/types": "1.0.2"
+        "@risedle/types": "1.1.1"
     },
     "exports": {
         "./*": "./dist/*.js"


### PR DESCRIPTION
Previously we can't do something like this:

```typescript
import { Binance } from "@risedle/chains";
```

this pull request fix that