### PR TITLE
fix(@risedle/chains): run build on root

### DIFF
--- a/.github/workflows/risedle-chains-release.yml
+++ b/.github/workflows/risedle-chains-release.yml
@@ -23,7 +23,6 @@ jobs:
         run: npm install
       - name: Build
         run: npm run build
-        working-directory: ./packages/chains
       - name: Test
         run: npm test
         working-directory: ./packages/chains

--- a/.github/workflows/risedle-chains-release.yml
+++ b/.github/workflows/risedle-chains-release.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - "packages/chains/**"
+      - ".github/workflows/risedle-chains-release.yml"
 
 jobs:
   release:


### PR DESCRIPTION
There is this weird build issue https://github.com/risedle/monorepo/runs/6953926041?check_suite_focus=true

`monorepo` workflow build doesn't fail, but this one is. 

Not sure what happen but this pull request is building `@risedle/chains` from the monorepo root instead of package directory