### PR TITLE
fix(@risedle/types): publish on latest tag by default

### DIFF
--- a/.github/workflows/risedle-types-release.yml
+++ b/.github/workflows/risedle-types-release.yml
@@ -24,7 +24,6 @@ jobs:
         run: npm install
       - name: Build
         run: npm run build
-        working-directory: ./packages/types
       - name: Set access to public
         run: npm config set access public
         working-directory: ./packages/types

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -29,6 +29,7 @@
         "url": "https://github.com/pyk"
     },
     "contributors": [],
+    "dependencies": {},
     "devDependencies": {
         "@semantic-release/git": "10.0.1",
         "semantic-release": "19.0.3"
@@ -88,9 +89,12 @@
             ]
         ]
     },
-    "dependencies": {},
     "exports": {
         ".": "./dist/index.js",
         "./*": "./dist/*.js"
+    },
+    "publishConfig": {
+        "registry": "https://registry.npmjs.org/",
+        "tag": "latest"
     }
 }


### PR DESCRIPTION
Publish `@risedle/types` on `latest` tag by default