### PR TITLE
fix(subgraphs/flt): add FLT to abis section in TokenCreated event 

### DIFF
--- a/subgraphs/flt/subgraph.yaml
+++ b/subgraphs/flt/subgraph.yaml
@@ -23,6 +23,8 @@ dataSources:
           file: ./abis/FLTFactory.json
         - name: ERC20
           file: ./abis/ERC20.json
+        - name: FLT
+          file: ./abis/FLT.json
       eventHandlers:
         - event: TokenCreated(address,string,string,bytes,uint256)
           handler: handleTokenCreated
@@ -45,6 +47,10 @@ dataSources:
       abis:
         - name: AccessControlledOffchainAggregator
           file: ./abis/AccessControlledOffchainAggregator.json
+        - name: FLT
+          file: ./abis/FLT.json
+        - name: RariFusePriceOracleAdapter
+          file: ./abis/RariFusePriceOracleAdapter.json
       eventHandlers:
         - event: AnswerUpdated(indexed int256,indexed uint256,uint256)
           handler: handleAnswerUpdated


### PR DESCRIPTION
Error:

```
Subgraph failed with non-deterministic error: failed to process trigger: block #19487278 (0x368f…c69a), transaction 853d3ac75a279b925326dd91252a255f97dbcbb503789713b3ad60219b7b6955: Could not find ABI for contract "FLT", try adding it to the 'abis' section of the subgraph manifest wasm backtrace: 0: 0x3472 - <unknown>!~lib/@graphprotocol/graph-ts/chain/ethereum/ethereum.SmartContract#call 1: 0x37dc - <unknown>!src/factory/handleTokenCreated , retry_delay_s: 960, attempt: 3
```