### PR TITLE
fix(apps/rebalancer): disable build inside docker image

### DIFF
--- a/apps/rebalancer/Dockerfile
+++ b/apps/rebalancer/Dockerfile
@@ -13,6 +13,5 @@ COPY . /app/
 RUN ls -a
 
 RUN npm install
-RUN npm run build
 
 CMD ["node", "./dist/cron.js"]


### PR DESCRIPTION
Fix this build https://github.com/risedle/monorepo/runs/7319033348?check_suite_focus=true