### PR TITLE
fix(@risedle/types): fix auto-release workflow

### DIFF
--- a/.github/workflows/risedle-types-release.yml
+++ b/.github/workflows/risedle-types-release.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GH_TOKEN }}
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
@@ -29,7 +31,7 @@ jobs:
         working-directory: ./packages/types
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GIT_AUTHOR_NAME: Risedle
           GIT_AUTHOR_EMAIL: github@risedle.com


### PR DESCRIPTION
Use github token when checkout repo in the github action vm