### PR TITLE
chore(apps/interface): set ChainSwitcherPopupBackground margin to 0

### DIFF
--- a/apps/interface/components/ChainSwitcher/index.tsx
+++ b/apps/interface/components/ChainSwitcher/index.tsx
@@ -147,10 +147,14 @@ export const ChainSwitcher = (props: ButtonProps) => {
                         height="100%"
                         left="0"
                         top="0"
+                        margin="0 !important"
                         background={blur}
                         backdropFilter="blur(12px)"
                         zIndex="10"
-                        display={isOpen ? "block" : "none"}
+                        display={{
+                            base: isOpen ? "block" : "none",
+                            tablet: "none",
+                        }}
                     />
                 </>
             )}


### PR DESCRIPTION
1. Set margin to `0 !important`
2. Hide backdrop blur on tablet or larger screen