### PR TITLE
chore(apps/interface): hide FooterBar on mobile

### DIFF
--- a/apps/interface/components/FooterBar/index.tsx
+++ b/apps/interface/components/FooterBar/index.tsx
@@ -21,7 +21,12 @@ export const FooterBar = () => {
     const gray12 = useColorModeValue("gray.light.12", "gray.dark.12");
 
     return (
-        <Container maxW="7xl" data-testid="FooterBar" marginTop="10">
+        <Container
+            maxW="7xl"
+            data-testid="FooterBar"
+            marginTop="10"
+            display={{ base: "none", tablet: "block" }}
+        >
             <Flex
                 borderTop="1px"
                 borderColor={gray3}

--- a/apps/interface/components/TokenCard/cards.tsx
+++ b/apps/interface/components/TokenCard/cards.tsx
@@ -20,6 +20,7 @@ export const TokenCards = (props: TokenCardsProps) => {
                 spacing="6"
                 margin="auto"
                 maxW={{ base: "400px", laptop: "730px", desktop: "100%" }}
+                marginBottom={{ base: "28", tablet: "0" }}
             >
                 {cards}
             </SimpleGrid>


### PR DESCRIPTION
TODO:
Even though the footer bar is hidden on mobile, it still looks like this

![image](https://user-images.githubusercontent.com/81855912/180899323-6dc25989-e4b9-4d69-8d0a-3b59ca7d45b0.png)

The bottom token card content is cut. I'll make a new issue in linear to add margin bottom on the body for mobile layout.