### PR TITLE
chore(apps/interface): add dashed border on UserPosition

### DIFF
--- a/apps/interface/components/TradeInfoCard/UserPosition.tsx
+++ b/apps/interface/components/TradeInfoCard/UserPosition.tsx
@@ -56,6 +56,7 @@ export const TradeInfoCardUserPosition = (
 
     return (
         <VStack
+            data-testid="TradeInfoCardUserPosition"
             width="100%"
             gap={{ base: "4", tablet: "0" }}
             {...boxProps}

--- a/apps/interface/components/TradeInfoCard/UserPosition.tsx
+++ b/apps/interface/components/TradeInfoCard/UserPosition.tsx
@@ -41,6 +41,7 @@ export const TradeInfoCardUserPosition = (
     // Styles
     const gray3 = useColorModeValue("gray.light.3", "gray.dark.3");
     const gray4 = useColorModeValue("gray.light.4", "gray.dark.4");
+    const gray5 = useColorModeValue("gray.light.5", "gray.dark.5");
     const gray10 = useColorModeValue("gray.light.10", "gray.dark.10");
     const accent = useColorModeValue(
         `${chainSlug}.button.bg.light`,
@@ -54,9 +55,26 @@ export const TradeInfoCardUserPosition = (
     const pnlColor = pnlPercent >= 0 ? green11 : red11;
 
     return (
-        <VStack width="100%" gap={6} {...boxProps} margin="0 !important">
-            <Flex width="100%">
-                <HStack gap="3" flex="1">
+        <VStack
+            width="100%"
+            gap={{ base: "4", tablet: "0" }}
+            {...boxProps}
+            margin="0 !important"
+        >
+            <Flex
+                width="100%"
+                borderY={{ base: "none", tablet: "1px" }}
+                borderColor={{ tablet: gray5 }}
+                borderStyle={{ tablet: "dashed" }}
+            >
+                <HStack
+                    gap="3"
+                    flex="1"
+                    py={{ base: "0", tablet: "4" }}
+                    borderRight={{ base: "none", tablet: "1px" }}
+                    borderColor={{ tablet: gray5 }}
+                    borderStyle={{ tablet: "dashed" }}
+                >
                     <Circle size="8" background={gray3}>
                         <PieIcon color={accent} />
                     </Circle>
@@ -95,7 +113,12 @@ export const TradeInfoCardUserPosition = (
                         </Skeleton>
                     </VStack>
                 </HStack>
-                <HStack gap="3" flex="1">
+                <HStack
+                    gap="3"
+                    flex="1"
+                    py={{ base: "0", tablet: "4" }}
+                    ml={{ base: "0", tablet: "4" }}
+                >
                     <Circle size="8" background={gray3}>
                         <CoinIcon color={accent} />
                     </Circle>
@@ -130,7 +153,14 @@ export const TradeInfoCardUserPosition = (
                 </HStack>
             </Flex>
             <Flex width="100%" margin="0 !important">
-                <HStack gap="3" flex="1">
+                <HStack
+                    gap="3"
+                    flex="1"
+                    py={{ base: "0", tablet: "4" }}
+                    borderRight={{ base: "none", tablet: "1px" }}
+                    borderColor={{ tablet: gray5 }}
+                    borderStyle={{ tablet: "dashed" }}
+                >
                     <Circle size="8" background={gray3}>
                         <MetricIcon color={accent} />
                     </Circle>
@@ -176,7 +206,12 @@ export const TradeInfoCardUserPosition = (
                         </Skeleton>
                     </VStack>
                 </HStack>
-                <HStack gap="3" flex="1">
+                <HStack
+                    gap="3"
+                    flex="1"
+                    py={{ base: "0", tablet: "4" }}
+                    ml={{ base: "0", tablet: "4" }}
+                >
                     <Circle size="8" background={gray3}>
                         <DollarIcon color={accent} />
                     </Circle>

--- a/apps/interface/components/TradeInfoCard/index.tsx
+++ b/apps/interface/components/TradeInfoCard/index.tsx
@@ -63,7 +63,12 @@ export const TradeInfoCard = (props: TradeInfoCardProps) => {
             {/* Show price chart */}
             <PriceChart timeframes={timeframes} />
 
-            <Box width="100%" paddingX="4" margin="0 !important">
+            <Box
+                width="100%"
+                paddingX="4"
+                margin="0 !important"
+                display={{ base: "block", tablet: "none" }}
+            >
                 <Divider borderStyle="dashed" borderColor={gray5} />
             </Box>
 

--- a/apps/interface/components/TradeInfoCard/index.tsx
+++ b/apps/interface/components/TradeInfoCard/index.tsx
@@ -76,6 +76,7 @@ export const TradeInfoCard = (props: TradeInfoCardProps) => {
             <TradeInfoCardUserPositionContainer
                 paddingX="4"
                 paddingBottom="4"
+                paddingTop="2"
                 fltAddress={address}
             />
         </VStack>


### PR DESCRIPTION
## RIS-580
1. Add dashed border on tablet or larger screen
2. For mobile sceen, we use divider, but for tablet or larger screen, we hide the divider and use border instead. The reason is becase we have `gap='4'` in the `VStack` container, so if we use divider in tablet or larger screen, the border will be separated by those gap.