### PR TITLE
chore(apps/interface): use formatPercent to format percentage

### DIFF
--- a/apps/interface/components/TokenCardInfo/index.tsx
+++ b/apps/interface/components/TokenCardInfo/index.tsx
@@ -10,6 +10,7 @@ import {
 
 // Utils
 import { formatUSD } from "../../utils/formatUSD";
+import { formatPercent } from "../../utils/formatPercent";
 
 // Sub-components
 import { ArrowDownIcon } from "../Icons/ArrowDown";
@@ -88,7 +89,7 @@ export const TokenCardInfo = (props: TokenCardInfoProps) => {
                                 fontFamily="mono"
                                 margin="0 !important"
                             >
-                                {priceChangePercent?.toFixed(2)}%
+                                {formatPercent(priceChangePercent / 100)}
                             </Text>
                         </Center>
                     </HStack>

--- a/apps/interface/components/TradeInfoCard/LatestPrice.tsx
+++ b/apps/interface/components/TradeInfoCard/LatestPrice.tsx
@@ -10,6 +10,7 @@ import {
 
 // Utils
 import { formatUSD } from "../../utils/formatUSD";
+import formatPercent from "../../utils/formatPercent";
 
 // Sub-components
 import ArrowDownIcon from "../Icons/ArrowDown";
@@ -116,10 +117,7 @@ export const TradeInfoCardLatestPrice = (
                             >
                                 {priceChangePercent > 0 ? "+" : ""}
                                 {formatUSD(priceChangeUSD)} (
-                                {priceChangePercent > 0
-                                    ? priceChangePercent?.toFixed(2)
-                                    : (priceChangePercent * -1).toFixed(2)}
-                                %)
+                                {formatPercent(priceChangePercent / 100)})
                             </Text>
                         </Center>
                     </HStack>

--- a/apps/interface/components/TradeInfoCard/UserPosition.tsx
+++ b/apps/interface/components/TradeInfoCard/UserPosition.tsx
@@ -22,6 +22,7 @@ import ArrowUpIcon from "../Icons/ArrowUp";
 import ArrowDownIcon from "../Icons/ArrowDown";
 
 import InfoTooltip from "../InfoTooltip";
+import formatPercent from "../../utils/formatPercent";
 
 interface TradeInfoCardUserPositionProps extends BoxProps {
     balance: number;
@@ -168,8 +169,7 @@ export const TradeInfoCardUserPosition = (
                                         fontFamily="mono"
                                         margin="0 !important"
                                     >
-                                        {pnlPercent >= 0 ? "+" : ""}
-                                        {pnlPercent.toFixed(2)}%
+                                        {formatPercent(pnlPercent)}
                                     </Text>
                                 </Center>
                             </HStack>

--- a/apps/interface/tests/utils/formatPercent.spec.ts
+++ b/apps/interface/tests/utils/formatPercent.spec.ts
@@ -1,0 +1,8 @@
+import { formatPercent } from "../../utils/formatPercent";
+
+describe("formatPercent", () => {
+    it("should return correct percent string", () => {
+        const percent = formatPercent(0.12345);
+        expect(percent).toBe("+12.35%");
+    });
+});

--- a/apps/interface/utils/formatPercent.ts
+++ b/apps/interface/utils/formatPercent.ts
@@ -1,0 +1,7 @@
+export const formatPercent = new Intl.NumberFormat("en-US", {
+    style: "percent",
+    maximumFractionDigits: 2,
+    signDisplay: "always",
+}).format;
+
+export default formatPercent;


### PR DESCRIPTION
## RIS-576
the `priceChangePercent` data from `useFuseLeveragedTokenInfo` already defined in percentage, so we need to divide it with `100` again when using `formatPercentage` (using `Intl`) utils. Wdyt guys? Should we use `Intl` or other way to format percent?
