### PR TITLE
feat(apps/interface): add dashed component

### DIFF
--- a/apps/interface/components/FuseLeveragedTokenInfoCard/index.tsx
+++ b/apps/interface/components/FuseLeveragedTokenInfoCard/index.tsx
@@ -7,7 +7,6 @@ import {
     Link,
     Center,
     Tooltip,
-    Divider,
 } from "@chakra-ui/react";
 import { utils } from "ethers";
 

--- a/apps/interface/components/FuseLeveragedTokenInfoCard/index.tsx
+++ b/apps/interface/components/FuseLeveragedTokenInfoCard/index.tsx
@@ -23,6 +23,7 @@ import ArrowTopRightIcon from "../Icons/ArrowTopRight";
 
 // Sub-components
 import FuseLeveragedTokenInfoCardStatsContainer from "./StatsContainer";
+import { Dash } from "../../uikit/DashedComponent/DashedComponent";
 
 interface FuseLeveragedTokenInfoCardProps extends BoxProps {
     flt: FuseLeveragedToken;
@@ -135,14 +136,7 @@ export const FuseLeveragedTokenInfoCard = (
                     </Link>
                 </Tooltip>
             </HStack>
-
-            {/* Divider */}
-            <Divider
-                borderStyle="dashed"
-                borderColor={gray5}
-                margin="0 !important"
-            />
-
+            <Dash />
             {/* Stats */}
             <FuseLeveragedTokenInfoCardStatsContainer
                 paddingX="4"

--- a/apps/interface/components/LatestBackingsCard/index.tsx
+++ b/apps/interface/components/LatestBackingsCard/index.tsx
@@ -4,7 +4,6 @@ import {
     VStack,
     Text,
     Flex,
-    StackDivider,
     HStack,
 } from "@chakra-ui/react";
 
@@ -15,6 +14,7 @@ import formatTokenBalance from "../../utils/formatTokenBalance";
 
 // Sub-components
 import InfoTooltip from "../InfoTooltip";
+import { Dash } from "../../uikit/DashedComponent/DashedComponent";
 
 interface LatestBackingsCardProps extends BoxProps {
     flt: FuseLeveragedToken;
@@ -100,13 +100,7 @@ export const LatestBackingsCard = (props: LatestBackingsCardProps) => {
                         Date
                     </Text>
                     <VStack
-                        divider={
-                            <StackDivider
-                                borderColor={gray5}
-                                borderStyle="dashed"
-                                margin="0 !important"
-                            />
-                        }
+                        divider={<Dash />}
                         margin="0 !important"
                         gap={4}
                         width="100%"
@@ -145,13 +139,7 @@ export const LatestBackingsCard = (props: LatestBackingsCardProps) => {
                         />
                     </HStack>
                     <VStack
-                        divider={
-                            <StackDivider
-                                borderColor={gray5}
-                                borderStyle="dashed"
-                                margin="0 !important"
-                            />
-                        }
+                        divider={<Dash />}
                         margin="0 !important"
                         gap={4}
                         width="100%"
@@ -197,13 +185,7 @@ export const LatestBackingsCard = (props: LatestBackingsCardProps) => {
                         />
                     </HStack>
                     <VStack
-                        divider={
-                            <StackDivider
-                                borderColor={gray5}
-                                borderStyle="dashed"
-                                margin="0 !important"
-                            />
-                        }
+                        divider={<Dash />}
                         margin="0 !important"
                         gap={4}
                         width="100%"

--- a/apps/interface/uikit/DashedComponent/DashedComponent.tsx
+++ b/apps/interface/uikit/DashedComponent/DashedComponent.tsx
@@ -1,5 +1,4 @@
 import {
-    border,
     Box,
     BoxProps,
     Flex,

--- a/apps/interface/uikit/DashedComponent/DashedComponent.tsx
+++ b/apps/interface/uikit/DashedComponent/DashedComponent.tsx
@@ -1,0 +1,62 @@
+import {
+    border,
+    Box,
+    BoxProps,
+    Flex,
+    HStack,
+    useColorModeValue,
+} from "@chakra-ui/react";
+import React from "react";
+
+function Dash({ children }: { children?: React.ReactNode }) {
+    const borderColor = useColorModeValue("#E8E8E8", "#2E2E2E");
+
+    if (children) {
+        return (
+            <Flex w="100%" alignItems="center">
+                <Box
+                    h="1px"
+                    flex="1"
+                    backgroundImage={`linear-gradient(to right, ${borderColor} 60%, rgba(255, 255, 255, 0) 0%);`}
+                    backgroundSize="10px 1px"
+                    order={2}
+                />
+                {children}
+            </Flex>
+        );
+    }
+    return (
+        <HStack
+            width="100%"
+            h="1px"
+            backgroundImage={`linear-gradient(to right, ${borderColor} 60%, rgba(255, 255, 255, 0) 0%);`}
+            backgroundSize="10px 1px"
+        />
+    );
+}
+
+type DashTextVariant = "left" | "rigth";
+
+type TextDashProps = {
+    textPosition?: DashTextVariant;
+} & BoxProps;
+
+const TextDash = ({ textPosition = "left", ...props }: TextDashProps) => {
+    const textColor = useColorModeValue("gray.light.12", "gray.dark.12 ");
+    return (
+        <Box
+            fontFamily="inter"
+            fontWeight={600}
+            fontSize="sm"
+            color={textColor}
+            margin={textPosition === "left" ? "0 6px 0 0" : "0 0 0 6px"}
+            order={textPosition === "left" ? "1" : "3"}
+            alignSelf="start"
+            {...props}
+        >
+            {props.children}
+        </Box>
+    );
+};
+
+export { Dash, TextDash };


### PR DESCRIPTION
create dashed component based on figma. 

current implementation : 
![image](https://user-images.githubusercontent.com/1397612/181204172-70f98406-fc33-42b8-a5b5-89faadf65bf6.png)


this dashed component also can be used with left or right text.

example

```
<Dash>
<TextDash variant=left | right>
Left Text
</TextDash>
</Dash>
```