### PR TITLE
fix(apps/interface): price chart is hidden on trade page (mobile)

### DIFF
--- a/apps/interface/components/PriceChart/index.tsx
+++ b/apps/interface/components/PriceChart/index.tsx
@@ -7,17 +7,19 @@ import {
     SimpleGrid,
     useColorModeValue,
     BoxProps,
+    ResponsiveValue,
 } from "@chakra-ui/react";
 
 import { PriceChartLine, PriceChartLineProps } from "./Line";
 
 interface PriceChartProps extends BoxProps {
     timeframes: Record<string, PriceChartLineProps>;
+    displayChart: ResponsiveValue<"block" | "none">;
 }
 
 export const PriceChart = (props: PriceChartProps) => {
     // Data
-    const { timeframes, ...boxProps } = props;
+    const { timeframes, displayChart, ...boxProps } = props;
 
     // Styles
     const gray2 = useColorModeValue("gray.light.2", "gray.dark.2");
@@ -65,7 +67,7 @@ export const PriceChart = (props: PriceChartProps) => {
             defaultIndex={0}
             width="100%"
             marginTop="0 !important"
-            display={{ base: "none", tablet: "block" }}
+            display={displayChart}
         >
             <TabPanels>{panels}</TabPanels>
             <TabList borderBottom="0" paddingX="4" marginTop="2">

--- a/apps/interface/components/PriceChart/index.tsx
+++ b/apps/interface/components/PriceChart/index.tsx
@@ -14,7 +14,7 @@ import { PriceChartLine, PriceChartLineProps } from "./Line";
 
 interface PriceChartProps extends BoxProps {
     timeframes: Record<string, PriceChartLineProps>;
-    displayChart: ResponsiveValue<"block" | "none">;
+    displayChart?: ResponsiveValue<"block" | "none">;
 }
 
 export const PriceChart = (props: PriceChartProps) => {

--- a/apps/interface/components/TokenCard/index.tsx
+++ b/apps/interface/components/TokenCard/index.tsx
@@ -51,7 +51,10 @@ export const TokenCard = (props: TokenCardProps) => {
             <TokenCardTitle name={name} symbol={symbol} />
 
             {/* Show price chart */}
-            <PriceChart timeframes={timeframes} />
+            <PriceChart
+                timeframes={timeframes}
+                displayChart={{ base: "none", tablet: "block" }}
+            />
 
             {/* Show description */}
             <Text

--- a/apps/interface/components/TradeInfoCard/index.tsx
+++ b/apps/interface/components/TradeInfoCard/index.tsx
@@ -64,7 +64,6 @@ export const TradeInfoCard = (props: TradeInfoCardProps) => {
             {/* The props 'display' and 'justifyContent' is used to prevent timeframes stretch in trade page */}
             <PriceChart
                 timeframes={timeframes}
-                displayChart="block"
                 display="flex"
                 justifyContent={{ base: "center", tablet: "start" }}
             />

--- a/apps/interface/components/TradeInfoCard/index.tsx
+++ b/apps/interface/components/TradeInfoCard/index.tsx
@@ -64,6 +64,7 @@ export const TradeInfoCard = (props: TradeInfoCardProps) => {
             {/* The props 'display' and 'justifyContent' is used to prevent timeframes stretch in trade page */}
             <PriceChart
                 timeframes={timeframes}
+                displayChart="block"
                 display="flex"
                 justifyContent={{ base: "center", tablet: "start" }}
             />


### PR DESCRIPTION
Display chart in trade page, even when the screen is smaller than tablet