### PR TITLE
chore(apps/interface): update StickyFooter space

### DIFF
--- a/apps/interface/components/FooterBar/Sticky.tsx
+++ b/apps/interface/components/FooterBar/Sticky.tsx
@@ -24,29 +24,12 @@ export const StickyFooterBar = () => {
         <VStack
             data-testid="StickyFooterBar"
             marginTop="4"
+            gap="4"
             width="100%"
             alignItems="center"
+            py="6"
         >
-            <HStack gap={2}>
-                <NextLink href="https://docs.risedle.com" passHref>
-                    <Link
-                        fontSize="sm"
-                        lineHeight="4"
-                        color={gray10}
-                        _hover={{ color: gray12 }}
-                        target="_blank"
-                        data-testid="FooterBarLinkDocs"
-                    >
-                        <Center>
-                            Docs
-                            <ArrowTopRightIcon
-                                w="14px"
-                                h="14px"
-                                color={gray10}
-                            />
-                        </Center>
-                    </Link>
-                </NextLink>
+            <HStack gap="6">
                 <NextLink href="https://twitter.com/risedle" passHref>
                     <Link
                         fontSize="sm"
@@ -99,6 +82,25 @@ export const StickyFooterBar = () => {
                     >
                         <Center>
                             Github
+                            <ArrowTopRightIcon
+                                w="14px"
+                                h="14px"
+                                color={gray10}
+                            />
+                        </Center>
+                    </Link>
+                </NextLink>
+                <NextLink href="https://docs.risedle.com" passHref>
+                    <Link
+                        fontSize="sm"
+                        lineHeight="4"
+                        color={gray10}
+                        _hover={{ color: gray12 }}
+                        target="_blank"
+                        data-testid="FooterBarLinkDocs"
+                    >
+                        <Center>
+                            Docs
                             <ArrowTopRightIcon
                                 w="14px"
                                 h="14px"


### PR DESCRIPTION
1. Update horizontal spacing to 24px (for links)
2. Add padding y = 24px
3. Add gap between links & `Risedle Labs` text = 16px
4. Update links order (docs now at the end)

Before:
![image](https://user-images.githubusercontent.com/81855912/183014048-ac4afca3-e372-4789-b988-3b4c4d0bfdc1.png)

After:
![image](https://user-images.githubusercontent.com/81855912/183014078-993bc688-32d9-437b-ab97-c78a7292bcef.png)
