### PR TITLE
chore(apps/interface): increase code coverage for DarkmodeToggle

### DIFF
--- a/apps/interface/components/Icons/Darkmode.tsx
+++ b/apps/interface/components/Icons/Darkmode.tsx
@@ -2,7 +2,7 @@ import { Icon, IconProps } from "@chakra-ui/react";
 
 const DarkmodeIcon = (props: IconProps) => {
     return (
-        <Icon viewBox="0 0 16 16" {...props}>
+        <Icon viewBox="0 0 16 16" {...props} data-testid="DarkmodeIcon">
             <path
                 fillRule="evenodd"
                 clipRule="evenodd"

--- a/apps/interface/components/Icons/Lightmode.tsx
+++ b/apps/interface/components/Icons/Lightmode.tsx
@@ -2,7 +2,7 @@ import { Icon, IconProps } from "@chakra-ui/react";
 
 const LightmodeIcon = (props: IconProps) => {
     return (
-        <Icon viewBox="0 0 16 16" {...props}>
+        <Icon viewBox="0 0 16 16" {...props} data-testid="LightmodeIcon">
             <path
                 fillRule="evenodd"
                 clipRule="evenodd"

--- a/apps/interface/tests/components/DarkmodeToggle.spec.tsx
+++ b/apps/interface/tests/components/DarkmodeToggle.spec.tsx
@@ -1,53 +1,25 @@
-import { screen, render } from "@testing-library/react";
-import chakra from "../utils/chakra";
+import { screen, fireEvent, waitFor } from "@testing-library/react";
+import renderApp from "../utils/renderApp";
 
 import { DarkmodeToggle } from "@/components/DarkmodeToggle";
 
-afterEach(() => {
-    // restore the spy created with spyOn
-    jest.restoreAllMocks();
-});
-
-describe("Given useColorMode == 'dark'", () => {
-    it("<DarkmodeIcon /> should be rendered", () => {
-        const useColorMode = jest.spyOn(chakra, "useColorMode");
-        useColorMode.mockReturnValue({ colorMode: "dark" });
-
-        render(<DarkmodeToggle />);
-        setTimeout(() => {
-            const darkmodeIcon = screen.queryByTestId("DarkmodeIcon");
-            expect(darkmodeIcon).toBeInTheDocument();
-        }, 500);
+describe("Given <DarkmodeToggle /> is rendered", () => {
+    beforeEach(() => {
+        renderApp(<DarkmodeToggle />);
     });
 
-    it("<LightmodeIcon /> should not be rendered", () => {
-        const useColorMode = jest.spyOn(chakra, "useColorMode");
-        useColorMode.mockReturnValue({ colorMode: "dark" });
-
-        render(<DarkmodeToggle />);
-        setTimeout(() => {
-            const lightmodeIcon = screen.queryByTestId("LightmodeIcon");
-            expect(lightmodeIcon).not.toBeInTheDocument();
-        }, 500);
-    });
-});
-
-describe("Given useColorMode == 'light'", () => {
-    it("<LightmodeIcon /> should be rendered", () => {
-        const useColorMode = jest.spyOn(chakra, "useColorMode");
-        useColorMode.mockReturnValue({ colorMode: "light" });
-
-        render(<DarkmodeToggle />);
+    it("should render lightmode icon by default", () => {
         const lightmodeIcon = screen.queryByTestId("LightmodeIcon");
         expect(lightmodeIcon).toBeInTheDocument();
     });
 
-    it("<DarkmodeIcon /> should not be rendered", () => {
-        const useColorMode = jest.spyOn(chakra, "useColorMode");
-        useColorMode.mockReturnValue({ colorMode: "light" });
+    it("should render darkmode icon when clicked", async () => {
+        const toggle = screen.queryByTestId("DarkmodeToggle");
+        fireEvent.click(toggle);
 
-        render(<DarkmodeToggle />);
-        const darkmodeIcon = screen.queryByTestId("DarkmodeIcon");
-        expect(darkmodeIcon).not.toBeInTheDocument();
+        await waitFor(() => {
+            const darkmodeIcon = screen.queryByTestId("DarkmodeIcon");
+            expect(darkmodeIcon).toBeInTheDocument();
+        });
     });
 });

--- a/apps/interface/tests/components/DarkmodeToggle.spec.tsx
+++ b/apps/interface/tests/components/DarkmodeToggle.spec.tsx
@@ -1,0 +1,53 @@
+import { screen, render } from "@testing-library/react";
+import chakra from "../utils/chakra";
+
+import { DarkmodeToggle } from "@/components/DarkmodeToggle";
+
+afterEach(() => {
+    // restore the spy created with spyOn
+    jest.restoreAllMocks();
+});
+
+describe("Given useColorMode == 'dark'", () => {
+    it("<DarkmodeIcon /> should be rendered", () => {
+        const useColorMode = jest.spyOn(chakra, "useColorMode");
+        useColorMode.mockReturnValue({ colorMode: "dark" });
+
+        render(<DarkmodeToggle />);
+        setTimeout(() => {
+            const darkmodeIcon = screen.queryByTestId("DarkmodeIcon");
+            expect(darkmodeIcon).toBeInTheDocument();
+        }, 500);
+    });
+
+    it("<LightmodeIcon /> should not be rendered", () => {
+        const useColorMode = jest.spyOn(chakra, "useColorMode");
+        useColorMode.mockReturnValue({ colorMode: "dark" });
+
+        render(<DarkmodeToggle />);
+        setTimeout(() => {
+            const lightmodeIcon = screen.queryByTestId("LightmodeIcon");
+            expect(lightmodeIcon).not.toBeInTheDocument();
+        }, 500);
+    });
+});
+
+describe("Given useColorMode == 'light'", () => {
+    it("<LightmodeIcon /> should be rendered", () => {
+        const useColorMode = jest.spyOn(chakra, "useColorMode");
+        useColorMode.mockReturnValue({ colorMode: "light" });
+
+        render(<DarkmodeToggle />);
+        const lightmodeIcon = screen.queryByTestId("LightmodeIcon");
+        expect(lightmodeIcon).toBeInTheDocument();
+    });
+
+    it("<DarkmodeIcon /> should not be rendered", () => {
+        const useColorMode = jest.spyOn(chakra, "useColorMode");
+        useColorMode.mockReturnValue({ colorMode: "light" });
+
+        render(<DarkmodeToggle />);
+        const darkmodeIcon = screen.queryByTestId("DarkmodeIcon");
+        expect(darkmodeIcon).not.toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
1. Implement test as defined in linear

Note:
https://github.com/risedle/monorepo/blob/2e241907086585022ff3ba1c9cc46590959ed417/apps/interface/tests/components/DarkmodeToggle.spec.tsx#L11-L33
I used `setTimeout()` here because of Chakra UI bug on `useColorMode` hook, where it always return `colorMode = 'light'` on initial render, then changed to `dark` after a few ms.