### PR TITLE
feat(apps/ipfs): setup ipfs daemon

### DIFF
--- a/apps/ipfs/Dockerfile
+++ b/apps/ipfs/Dockerfile
@@ -1,0 +1,2 @@
+FROM ipfs/kubo:latest
+

--- a/apps/ipfs/README.md
+++ b/apps/ipfs/README.md
@@ -1,0 +1,25 @@
+## Risedle IPFS Daemon
+
+This is source code of IPFS daemon that runs inside Risedle private network.
+
+### Setup
+
+Make sure you have installed [flyctl](https://fly.io/docs/flyctl/).
+
+Create new app by running the following command:
+
+```sh
+fly launch
+```
+
+Choose name and prefered region.
+
+Then deploy the app using the following command:
+
+```sh
+fly deploy
+```
+
+### Resources
+
+-   [Run IPFS inside Docker](https://docs.ipfs.tech/how-to/run-ipfs-inside-docker/)

--- a/apps/ipfs/fly.toml
+++ b/apps/ipfs/fly.toml
@@ -1,0 +1,30 @@
+app = "risedle-ipfs"
+kill_signal = "SIGINT"
+kill_timeout = 5
+processes = []
+
+[env]
+
+[experimental]
+  allowed_public_ports = []
+  auto_rollback = true
+
+[[services]]
+  internal_port = 5001
+  processes = ["app"]
+  protocol = "tcp"
+  script_checks = []
+  [services.concurrency]
+    hard_limit = 25
+    soft_limit = 20
+    type = "connections"
+
+  [[services.tcp_checks]]
+    grace_period = "1s"
+    interval = "15s"
+    restart_limit = 0
+    timeout = "2s"
+
+[mounts]
+    source="risedle_ipfs_data"
+    destination="/"


### PR DESCRIPTION
- Deploy ipfs daemon inside Risedle fly.io private network
- Use [ipfs kubo](https://docs.ipfs.tech/how-to/run-ipfs-inside-docker/#set-up) docker image

