### PR TITLE
fix(subgraphs/dex): set timestamp and blockNumber for pool

### DIFF
--- a/subgraphs/dex/protocols/uniswap-v3/handlers/handlePoolCreated.ts
+++ b/subgraphs/dex/protocols/uniswap-v3/handlers/handlePoolCreated.ts
@@ -80,6 +80,8 @@ export function handlePoolCreated(event: PoolCreated): void {
         protocol
     );
     pool.tokenCount = 2;
+    pool.createdAtTimestamp = event.block.timestamp;
+    pool.createdAtBlockNumber = event.block.number;
 
     // Get or create token<->pool mapping
     let token0Pool = getOrCreateTokenLiquidityPool(token0, pool, HALF_PERCENT);

--- a/subgraphs/dex/tests/uniswap-v3/handlePoolCreated.test.ts
+++ b/subgraphs/dex/tests/uniswap-v3/handlePoolCreated.test.ts
@@ -163,12 +163,9 @@ describe("handlePoolCreated", () => {
             assert.i32Equals(pool.tokenCount, 2);
             assert.bigIntEquals(
                 pool.createdAtTimestamp,
-                BigInt.fromString("0")
+                event.block.timestamp
             );
-            assert.bigIntEquals(
-                pool.createdAtBlockNumber,
-                BigInt.fromString("0")
-            );
+            assert.bigIntEquals(pool.createdAtBlockNumber, event.block.number);
 
             assert.stringEquals(
                 pool.totalValueLockedUSD.toString(),


### PR DESCRIPTION
update `pool.createdAtTimestamp` and `pool.createdAtBlockNumber`