### PR TITLE
chore(monorepo): update changesets ci

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -34,6 +34,7 @@ jobs:
           publish: pnpm publish -r --no-git-checks
           version: pnpm changeset version
           title: "chore(packages): update and publish packages"
+          setupGitUser: false
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -1,13 +1,14 @@
-name: Changesets
+name: changesets
 
 on:
   push:
     branches:
       - main
+    paths:
+      - ".changeset"
 
 jobs:
-  version:
-    name: Publish packages
+  publish:
     runs-on: ubuntu-latest
     steps:
       - name: 📬 Check out code
@@ -22,7 +23,7 @@ jobs:
           node-version: "18.7.0"
           cache: "pnpm"
       - name: 🍱 Install dependencies
-        run: pnpm install
+        run: pnpm install --ignore-scripts
       - name: 🦋 Setup .npmrc
         run:
           # prettier-ignore
@@ -30,9 +31,9 @@ jobs:
       - name: 🦋 Create and publish versions
         uses: changesets/action@v1
         with:
-          publish: pnpm publish -r
+          publish: pnpm publish -r --no-git-checks
           version: pnpm changeset version
-          commit: "chore(monorepo): version packages"
-          title: "chore(monorepo): version packages"
+          title: "chore(packages): update and publish packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Scope
List of affected projects:

n/a

## Description
Update the changesets github workflows

## Todo
Action items for this issue:

- [x] Update workflow and job name to `changesets / publish`
- [x] Set workflow to run only when there is change in `.changeset` directory
- [x] Use `--ignore-scripts` in `pnpm install`
- [x] Use `--no-git-checks` in `pnpm publish -r`
- [x] Update commit title to "chore(packages): publish"
- [x] Set setupGitUser to false

## Checklist
You should check this before requesting for review:

- [x] Pull request title is "chore(monorepo): update changesets ci"


## Linear
Fix RIS-783