### PR TITLE
fix(changesets): set git account identity

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -30,6 +30,10 @@ jobs:
         run:
           # prettier-ignore
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
+      - name: 🦋 Setup git user
+        run: |
+          git config user.email "github@risedle.com"
+          git config user.name "risedledev"
       - name: 🦋 Create and publish versions
         uses: changesets/action@v1
         with:


### PR DESCRIPTION
## Scope
List of affected projects:

n/a

## Description
Add github identity for changeset ci

## Todo
Action items for this issue:

- [x] set git user to risedledev/github@risedle.com

## Checklist
You should check this before requesting for review:

- [x] Pull request title is "fix(changesets): set git account identity"

## Linear
Fix RIS-786