### PR TITLE
fix(changesets): update workflow

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -30,17 +30,12 @@ jobs:
         run:
           # prettier-ignore
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
-      - name: 🦋 Setup git user
-        run: |
-          git config user.email "github@risedle.com"
-          git config user.name "risedledev"
       - name: 🦋 Create and publish versions
         uses: changesets/action@v1
         with:
-          publish: pnpm publish -r --no-git-checks
-          version: pnpm changeset version
+          version: pnpm changeset:version
+          publish: pnpm changeset:publish
           title: "chore(packages): update and publish packages"
-          setupGitUser: false
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
         "build": "turbo run build",
         "test": "turbo run test",
         "prepare": "husky install",
-        "postinstall": "pnpm prepare"
+        "postinstall": "pnpm prepare",
+        "changeset:version": "changeset version && pnpm install --lockfile-only",
+        "changeset:publish": "pnpm build && pnpm publish -r --no-git-checks"
     },
     "devDependencies": {
         "@changesets/cli": "2.24.4",


### PR DESCRIPTION
## Scope
List of affected projects:

- packages/*

## Description
We need to update the changeset workflow:
1. Enable setupGitUser
2. Remove github identity
3. Add `changeset:release` and `changset:version` command

```json
{
	"scripts": {
		"changeset:release": "pnpm build && changeset publish",
		"changeset:version": "changeset version && pnpm install --lockfile-only",
	}
}
```

## Todo
Action items for this issue:

- [x] Enable `setupGitUser`
- [x] Remove github identity
- [x] Update `version` and `publish` changeset ci

## Checklist
You should check this before requesting for review:

- [x] Pull request title is "fix(changesets): update workflow"

## Linear
Fix RIS-787