### PR TITLE
fix(changesets): update automatic release

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -30,17 +30,12 @@ jobs:
         run:
           # prettier-ignore
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
-      - name: 🦋 Setup git user
-        run: |
-          git config user.email "github@risedle.com"
-          git config user.name "risedledev"
       - name: 🦋 Create and publish versions
         uses: changesets/action@v1
         with:
-          publish: pnpm publish -r --no-git-checks
-          version: pnpm changeset version
+          version: pnpm changeset:version
+          publish: pnpm changeset:publish
           title: "chore(packages): update and publish packages"
-          setupGitUser: false
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -27,9 +27,11 @@ jobs:
       - name: 🍱 Install dependencies
         run: pnpm install --ignore-scripts
       - name: 🦋 Setup .npmrc
-        run:
+        run: |
           # prettier-ignore
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
+      - name: 🦋 Check .npmrc
+        run: cat .npmrc
       - name: 🦋 Create and publish versions
         uses: changesets/action@v1
         with:

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "test": "turbo run test",
         "prepare": "husky install",
         "postinstall": "pnpm prepare",
-        "changeset:version": "changeset version && pnpm install --lockfile-only",
+        "changeset:version": "changeset version && pnpm install",
         "changeset:publish": "pnpm build && pnpm publish -r --no-git-checks"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
         "build": "turbo run build",
         "test": "turbo run test",
         "prepare": "husky install",
-        "postinstall": "pnpm prepare"
+        "postinstall": "pnpm prepare",
+        "changeset:version": "changeset version && pnpm install --lockfile-only",
+        "changeset:publish": "pnpm build && pnpm publish -r --no-git-checks"
     },
     "devDependencies": {
         "@changesets/cli": "2.24.4",


### PR DESCRIPTION
## Scope
List of affected projects:

- packages/*

## Description
lockfile is not updated.

We need to check `.npmrc` and disable the `--lockfile-only` install. 

## Todo
Action items for this issue:

- [x] Print out `.npmrc`
- [x] Use the `pnpm changeset version`
- [x] Disable the `--lockfile-only` install on `changeset:version`

## Checklist
You should check this before requesting for review:

- [x] Pull request title is "fix(changesets): update automatic release"

## Linear
Fix RIS-788