### PR TITLE
fix(changesets): automatic release

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -30,8 +30,6 @@ jobs:
         run: |
           # prettier-ignore
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
-      - name: 🦋 Check .npmrc
-        run: cat .npmrc
       - name: 🦋 Create and publish versions
         uses: changesets/action@v1
         with:

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "test": "turbo run test",
         "prepare": "husky install",
         "postinstall": "pnpm prepare",
-        "changeset:version": "changeset version && pnpm install",
+        "changeset:version": "changeset version && pnpm install --ignore-scripts -r",
         "changeset:publish": "pnpm build && pnpm publish -r --no-git-checks"
     },
     "devDependencies": {


### PR DESCRIPTION
## Scope
List of affected projects:

- packages/*

## Description
Cannot commit due to when running `changeset:version`, the scripts is not ignored.

## Todo
Action items for this issue:

- [x] Add `--ignore-scripts`

## Checklist
You should check this before requesting for review:

- [x] Pull request title is "fix(changesets): automatic release"

## Linear
Fix RIS-789