### PR TITLE
fix(apps/assets): deploy script name

### DIFF
--- a/.github/workflows/apps-assets-prod.yml
+++ b/.github/workflows/apps-assets-prod.yml
@@ -43,4 +43,4 @@ jobs:
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-        run: pnpm deploy
+        run: pnpm pages:deploy

--- a/apps/assets/README.md
+++ b/apps/assets/README.md
@@ -21,5 +21,5 @@ version to Cloudflare Pages.
 Run the following command to deploy manually:
 
 ```sh
-pnpm deploy
+pnpm pages:deploy
 ```

--- a/apps/assets/package.json
+++ b/apps/assets/package.json
@@ -5,7 +5,7 @@
         "prettier": "prettier --check .",
         "optimize": "./optimize.sh",
         "optimize:svg": "svgo -f ./src/** -o ./public",
-        "deploy": "wrangler pages publish public --project-name=risedle-assets --branch=main"
+        "pages:deploy": "wrangler pages publish public --project-name=risedle-assets --branch=main"
     },
     "prettier": "@risedle/prettier-config",
     "devDependencies": {


### PR DESCRIPTION
## Scope
List of affected projects:

- apps/assets

## Description
Deploy command is clashed with builtin `pnpm deploy`.

Update the script name to `pages:deploy`.

## Todo
Action items for this pull request:

- [x] Update the script name to `pages:deploy`


## Checklist
You should check this before requesting for review:

- [x] Pull request title is "fix(apps/assets): deploy script name"

## Linear
Fix RIS-123