### PR TITLE
fix(coverage): add flags

### DIFF
--- a/.github/workflows/apps-api-prod.yml
+++ b/.github/workflows/apps-api-prod.yml
@@ -43,6 +43,7 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           directory: ./apps/api
+          flags: "apps-api"
       - name: 🦍 Check on test failures
         if: steps.test.outcome != 'success'
         run: exit 1

--- a/.github/workflows/apps-api-stag.yml
+++ b/.github/workflows/apps-api-stag.yml
@@ -44,6 +44,7 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           directory: ./apps/api
+          flags: "apps-api"
       - name: 🦍 Check on test failures
         if: steps.test.outcome != 'success'
         run: exit 1

--- a/.github/workflows/packages-chains.yml
+++ b/.github/workflows/packages-chains.yml
@@ -51,6 +51,7 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           directory: ./packages/chains
+          flags: "packages-chains"
       - name: 🦍 Check on test failures
         if: steps.test.outcome != 'success'
         run: exit 1

--- a/.github/workflows/packages-tokens.yml
+++ b/.github/workflows/packages-tokens.yml
@@ -51,6 +51,7 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           directory: ./packages/tokens
+          flags: "packages-tokens"
       - name: 🦍 Check on test failures
         if: steps.test.outcome != 'success'
         run: exit 1

--- a/packages/chains/.npmrc
+++ b/packages/chains/.npmrc
@@ -1,0 +1,1 @@
+recursive-install = false

--- a/packages/chains/package.json
+++ b/packages/chains/package.json
@@ -34,13 +34,13 @@
     },
     "prettier": "@risedle/prettier-config",
     "dependencies": {
-        "@risedle/types": "1.9.1"
+        "@risedle/types": "1.9.0"
     },
     "devDependencies": {
         "@jest/types": "28.1.3",
-        "@risedle/eslint-config": "0.1.1",
-        "@risedle/prettier-config": "0.1.1",
-        "@risedle/tsconfig": "0.2.1",
+        "@risedle/eslint-config": "0.1.0",
+        "@risedle/prettier-config": "0.1.0",
+        "@risedle/tsconfig": "0.2.0",
         "@types/jest": "29.0.0",
         "eslint": "8.23.0",
         "jest": "28.1.1",

--- a/packages/tokens/.npmrc
+++ b/packages/tokens/.npmrc
@@ -1,0 +1,1 @@
+recursive-install = false

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -34,13 +34,13 @@
     },
     "prettier": "@risedle/prettier-config",
     "dependencies": {
-        "@risedle/types": "1.9.1"
+        "@risedle/types": "1.9.0"
     },
     "devDependencies": {
         "@jest/types": "28.1.3",
-        "@risedle/eslint-config": "0.1.1",
-        "@risedle/prettier-config": "0.1.1",
-        "@risedle/tsconfig": "0.2.1",
+        "@risedle/eslint-config": "0.1.0",
+        "@risedle/prettier-config": "0.1.0",
+        "@risedle/tsconfig": "0.2.0",
         "@types/jest": "29.0.0",
         "eslint": "8.23.0",
         "jest": "28.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -213,10 +213,10 @@ importers:
   packages/chains:
     specifiers:
       "@jest/types": 28.1.3
-      "@risedle/eslint-config": 0.1.1
-      "@risedle/prettier-config": 0.1.1
-      "@risedle/tsconfig": 0.2.1
-      "@risedle/types": 1.9.1
+      "@risedle/eslint-config": 0.1.0
+      "@risedle/prettier-config": 0.1.0
+      "@risedle/tsconfig": 0.2.0
+      "@risedle/types": 1.9.0
       "@types/jest": 29.0.0
       eslint: 8.23.0
       jest: 28.1.1
@@ -225,12 +225,12 @@ importers:
       ts-node: 10.9.1
       typescript: 4.8.2
     dependencies:
-      "@risedle/types": link:../types
+      "@risedle/types": 1.9.0
     devDependencies:
       "@jest/types": 28.1.3
-      "@risedle/eslint-config": link:../eslint-config
-      "@risedle/prettier-config": link:../prettier-config
-      "@risedle/tsconfig": link:../tsconfig
+      "@risedle/eslint-config": 0.1.0
+      "@risedle/prettier-config": 0.1.0
+      "@risedle/tsconfig": 0.2.0
       "@types/jest": 29.0.0
       eslint: 8.23.0
       jest: 28.1.1_ts-node@10.9.1
@@ -281,10 +281,10 @@ importers:
   packages/tokens:
     specifiers:
       "@jest/types": 28.1.3
-      "@risedle/eslint-config": 0.1.1
-      "@risedle/prettier-config": 0.1.1
-      "@risedle/tsconfig": 0.2.1
-      "@risedle/types": 1.9.1
+      "@risedle/eslint-config": 0.1.0
+      "@risedle/prettier-config": 0.1.0
+      "@risedle/tsconfig": 0.2.0
+      "@risedle/types": 1.9.0
       "@types/jest": 29.0.0
       eslint: 8.23.0
       jest: 28.1.1
@@ -293,12 +293,12 @@ importers:
       ts-node: 10.9.1
       typescript: 4.8.3
     dependencies:
-      "@risedle/types": link:../types
+      "@risedle/types": 1.9.0
     devDependencies:
       "@jest/types": 28.1.3
-      "@risedle/eslint-config": link:../eslint-config
-      "@risedle/prettier-config": link:../prettier-config
-      "@risedle/tsconfig": link:../tsconfig
+      "@risedle/eslint-config": 0.1.0
+      "@risedle/prettier-config": 0.1.0
+      "@risedle/tsconfig": 0.2.0
       "@types/jest": 29.0.0
       eslint: 8.23.0
       jest: 28.1.1_ts-node@10.9.1
@@ -21519,7 +21519,7 @@ packages:
       pretty-format: 28.1.3
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1_xtowvbsomha52a5oqacf7oijd4
+      ts-node: 10.9.1_typescript@4.8.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -29950,7 +29950,7 @@ packages:
       "@jest/types": 28.1.3
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 28.1.1_y65h744brboeewhfxt6fxokeby
+      jest: 28.1.1_ts-node@10.9.1
       jest-util: 28.1.3
       json5: 2.2.1
       lodash.memoize: 4.1.2


### PR DESCRIPTION
## Scope
List of affected projects:

- packages/chains
- packages/tokens
- apps/api


## Description
Currently the coverage report is overwritten by latest test.

We need to use [Flags](https://docs.codecov.com/docs/flags) to 
solve this problem.

## Action items
Action items for this pull request:

- [ ] update apps-api-stag workflow
- [ ] update apps-api-prod workflow
- [ ] update packages-chains workflow
- [ ] update packages-tokens workflow


## Checklist
You should check this before requesting for review:

- [ ] Pull request title is "fix(coverage): add flags"

## Linear
Fix RIS-794