### PR TITLE
fix(changesets): simplify workflow

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -1,13 +1,21 @@
 name: changesets
 
+# Make sure changesets workflow is not running parallely
+concurrency: changesets-main
+
 on:
   push:
     branches:
       - main
     paths:
       - ".changeset/**"
+      - ".github/workflows/changesets.yml"
 
   workflow_dispatch:
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
 jobs:
   publish:
@@ -26,16 +34,28 @@ jobs:
           cache: "pnpm"
       - name: 🍱 Install dependencies
         run: pnpm install --ignore-scripts
-      - name: 🦋 Setup .npmrc
+      - name: 🦋 Check changeset
+        run: pnpm changeset status
+        id: check
+        continue-on-error: true
+      - name: 🦋 Build packages
+        if: steps.check.outcome == 'success'
+        run: pnpm packages:build
+      - name: 🦋 Bump version
+        if: steps.check.outcome == 'success'
+        run: pnpm packages:version
+      - name: 🦋 Publish
+        if: steps.check.outcome == 'success'
+        run: pnpm packages:publish
+      - name: 🦋 Update lockfile
+        if: steps.check.outcome == 'success'
+        run: pnpm install --lockfile-only
+      - name: 🦋 Push commits and tags
+        if: steps.check.outcome == 'success'
         run: |
-          # prettier-ignore
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
-      - name: 🦋 Create and publish versions
-        uses: changesets/action@v1
-        with:
-          version: pnpm changeset:version
-          publish: pnpm changeset:publish
-          title: "chore(packages): update and publish packages"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          git config user.email "github@risedle.com"
+          git config user.name "risedledev"
+          git status --porcelain
+          git add .
+          git commit -m "chore(packages): bump versions"
+          git push origin HEAD --follow-tags

--- a/apps/assets/package.json
+++ b/apps/assets/package.json
@@ -1,6 +1,6 @@
 {
     "name": "assets",
-    "private": "true",
+    "private": true,
     "scripts": {
         "prettier": "prettier --check .",
         "optimize": "./optimize.sh",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,9 @@
         "test": "turbo run test",
         "prepare": "husky install",
         "postinstall": "pnpm prepare",
-        "changeset:version": "changeset version && pnpm install --ignore-scripts -r",
-        "changeset:publish": "pnpm build && pnpm publish -r --no-git-checks"
+        "packages:build": "turbo run build --filter=./packages/*",
+        "packages:version": "changeset version",
+        "packages:publish": "changeset publish"
     },
     "devDependencies": {
         "@changesets/cli": "2.24.4",


### PR DESCRIPTION
## Scope
List of affected projects:

- packages/

## Description
Currently the automatic release process is not straightforward.

We want to remove the pull request process coz it breaks the build
due to `pnpm changeset version` update other packages that depends on
the updated package(s).

If `package.json` is updated and the dependency is not published yet,
the workflow(s) will fail.

We will use the following step by step to automate the release:
1. Developer run `pnpm changeset` locally
2. Developer commit the changeset and send pull request
3. If pull request is merged to main, it will publish the packages
   and push commit and tags.

## Action items
Action items for this pull request:

- [x] add concurrency to changesets workflow
- [x] Use `pnpm changeset status` to determine if changeset exists
- [x] Add `pnpm packages:build` to build all workspace inside `packages/*`
- [x] Add `pnpm packages:version` to bump the version
- [x] Add `pnpm packages:publish` to publish the packages
- [x] Update lockfile by running pnpm install
- [x] Add command to commit and push tags to branch master


## Checklist
You should check this before requesting for review:

- [x] Pull request title is "fix(changesets): simplify workflow"

## Linear
Fix RIS-795