### PR TITLE
fix(changesets): remove paths filter

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -7,15 +7,8 @@ on:
   push:
     branches:
       - main
-    paths:
-      - ".changeset/**"
-      - ".github/workflows/changesets.yml"
 
   workflow_dispatch:
-
-env:
-  GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
 jobs:
   publish:
@@ -47,6 +40,8 @@ jobs:
       - name: 🦋 Publish
         if: steps.check.outcome == 'success'
         run: pnpm packages:publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: 🦋 Update lockfile
         if: steps.check.outcome == 'success'
         run: pnpm install --lockfile-only

--- a/subgraphs/flt/package.json
+++ b/subgraphs/flt/package.json
@@ -1,5 +1,6 @@
 {
     "name": "flt",
+    "private": true,
     "license": "MIT",
     "scripts": {
         "codegen": "graph codegen",


### PR DESCRIPTION
## Scope
List of affected projects:

- packages/*

## Description
Based on the first run of updated [worfklow](https://github.com/risedle/monorepo/runs/8295132573?check_suite_focus=true),
it seems that changesets need to run on whatever updated files.

`changeset status` command is not simply check wether 
there is file in `.changeset` directory or not, it also check the all
defined `package.json` in all workspaces.

## Action items
Action items for this pull request:

- [x] Remove paths filter
- [x] Add `NODE_AUTH_TOKEN`
- [x] Set `subgraphs/flt` to private


## Checklist
You should check this before requesting for review:

- [ ] Pull request title is "fix(changesets): remove paths filter"
