### PR TITLE
fix(changesets): set auth via .npmrc

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -37,6 +37,14 @@ jobs:
       - name: 🦋 Bump version
         if: steps.check.outcome == 'success'
         run: pnpm packages:version
+      - name: 🦋 Create .npmrc
+        if: steps.check.outcome == 'success'
+        run: |
+          cat << EOF > "$HOME/.npmrc"
+            //registry.npmjs.org/:_authToken=$NPM_TOKEN
+          EOF
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: 🦋 Publish
         if: steps.check.outcome == 'success'
         run: pnpm packages:publish


### PR DESCRIPTION
## Scope
List of affected projects:

- packages/*

## Description
`NODE_AUTH_TOKEN` doesn't work with `pnpm packages:publish`.

We need to create `.npmrc` manually.

## Action items
Action items for this pull request:

- [x] Add `.npmrc`


## Checklist
You should check this before requesting for review:

- [x] Branch name is RIS-797
- [x] Pull request title is "fix(changesets): set auth via .npmrc"

