### PR TITLE
fix(apps/interface): install git on docker image

### DIFF
--- a/apps/interface/Dockerfile
+++ b/apps/interface/Dockerfile
@@ -1,5 +1,6 @@
 FROM node:18-alpine
-RUN apk update
+RUN apk update && apk upgrade && \
+    apk add --no-cache bash git openssh libc6-compat
 RUN npm install -g pnpm
 WORKDIR /app
 COPY . /app/


### PR DESCRIPTION
## Scope
List of affected projects:

- apps/interface

## Description
When we try to deploy the `apps/interface` it fails to build the Docker image
with the following error message:

```shell
> [7/8] RUN pnpm install --prod:
#10 25.34  at eth-json-rpc-filters@4.2.2
#10 25.34  at eth-json-rpc-middleware@6.0.0
#10 25.34  at eth-sig-util@1.4.2
#10 25.34 
#10 25.34 pnpm: Command failed with ENOENT: git ls-remote https://github.com/ethereumjs/ethereumjs-abi.git HEAD
#10 25.34 spawn git ENOENT
#10 25.34     at ChildProcess._handle.onexit (node:internal/child_process:283:19)
#10 25.34     at onErrorNT (node:internal/child_process:476:16)
#10 25.34     at process.processTicksAndRejections (node:internal/process/task_queues:82:21)
#10 25.34 Progress: resolved 1010, reused 0, downloaded 994, added 0
```

We need to install git on the docker image.

## Action items
Action items for this pull request:

- [x] Install git in Docker image

## Checklist
You should check this before requesting for review:

- [x] Branch name is RIS-803
- [x] Pull request title is "fix(apps/interface): install git on docker image"