### PR TITLE
fix(@risedle/tsconfig): include esm and cjs json files

### DIFF
--- a/.changeset/tidy-horses-beam.md
+++ b/.changeset/tidy-horses-beam.md
@@ -1,0 +1,5 @@
+---
+"@risedle/tsconfig": patch
+---
+
+Include esm.json and cjs.json

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -4,11 +4,7 @@
     "main": "index.js",
     "license": "MIT",
     "files": [
-        "base.json",
-        "nextjs.json",
-        "react-library.json",
-        "node.json",
-        "shared-library.json"
+        "*.json"
     ],
     "homepage": "https://risedle.com",
     "repository": {


### PR DESCRIPTION
## Scope
List of affected projects:

- packages/tsconfig

## Description

Currently `esm.json` and `cjs.json` is not uploaded in the npm module.


We need to add it to `files` config in the `package.json`.


## Action items
Action items for this pull request:

- [x] Update `package.json`
- [x] Create new changeset

## Checklist
You should check this before requesting for review:

- [x] Branch name use the the following format RIS-*
- [x] Pull request title is "fix(@risedle/tsconfig): include esm and cjs json files"
- [x] Make sure new files are 100% covered in [Risedle Code Coverage](https://coverage.risedle.com)