### PR TITLE
chore(apps/interface): refactor BackgroundGradient

### DIFF
--- a/apps/interface/components/BackgroundGradient/index.tsx
+++ b/apps/interface/components/BackgroundGradient/index.tsx
@@ -1,6 +1,6 @@
 import { BoxProps, Box, useColorModeValue } from "@chakra-ui/react";
 
-import { getBaseConfig } from "@/utils/getBaseConfig";
+import getBaseConfig from "@/utils/getBaseConfig";
 
 interface BackgroundGradientProps extends BoxProps {
     page: string; // 'home', 'trade' etc


### PR DESCRIPTION
## Scope
List of affected projects:

- apps/interface

## Description
We need to use default import for all imported utilities in [BackgroundGradient][1].

[1]: https://github.com/risedle/monorepo/blob/92a878c98f5e1ff10cc4420512ad8a626d3083dc/apps/interface/components/BackgroundGradient/index.tsx#L3

## Action items
Action items for this pull request:

- [x] Update `import {x} from "y"` to `import x from y`

## Checklist
You should check this before requesting for review:

- [x] Branch name use the the following format RIS-{NUMBER}
- [x] Pull request title is "chore(apps/interface): refactor BackgroundGradient imports"
- [x] Make sure new files are 100% covered in [Risedle Code Coverage](https://coverage.risedle.com)