### PR TITLE
chore(apps/interface): refactor TradePage imports

### DIFF
--- a/apps/interface/components/FuseLeveragedTokenInfoCard/index.tsx
+++ b/apps/interface/components/FuseLeveragedTokenInfoCard/index.tsx
@@ -17,7 +17,7 @@ interface FuseLeveragedTokenInfoCardProps extends BoxProps {
     flt: FuseLeveragedToken;
 }
 
-export const FuseLeveragedTokenInfoCard = (
+const FuseLeveragedTokenInfoCard = (
     props: FuseLeveragedTokenInfoCardProps
 ) => {
     // Data
@@ -76,3 +76,5 @@ export const FuseLeveragedTokenInfoCard = (
         </VStack>
     );
 };
+
+export default FuseLeveragedTokenInfoCard;

--- a/apps/interface/components/NavigationBarBottom/index.tsx
+++ b/apps/interface/components/NavigationBarBottom/index.tsx
@@ -4,7 +4,7 @@ import { ChainSwitcher } from "../ChainSwitcher";
 import { ConnectWalletButton } from "../ConnectWalletButton";
 import { NavigationBarBottomLinks } from "./links";
 
-export const NavigationBarBottom = () => {
+const NavigationBarBottom = () => {
     const gray2 = useColorModeValue("gray.light.2", "gray.dark.2");
     const gray4 = useColorModeValue("gray.light.4", "gray.dark.4");
     return (
@@ -28,3 +28,5 @@ export const NavigationBarBottom = () => {
         </Container>
     );
 };
+
+export default NavigationBarBottom;

--- a/apps/interface/pages/trade/[symbol].tsx
+++ b/apps/interface/pages/trade/[symbol].tsx
@@ -3,15 +3,15 @@ import { NextSeo } from "next-seo";
 import { Container, Flex, VStack } from "@chakra-ui/react";
 
 import getBaseConfig from "@/utils/getBaseConfig";
-import { fetchFuseLeveragedTokenSymbols } from "@/utils/fetchFuseLeveragedTokenSymbols";
-import { fetchFuseLeveragedTokenBySymbol } from "@/utils/fetchFuseLeveragedTokenBySymbol";
+import fetchFuseLeveragedTokenSymbols from "@/utils/fetchFuseLeveragedTokenSymbols";
+import fetchFuseLeveragedTokenBySymbol from "@/utils/fetchFuseLeveragedTokenBySymbol";
 import type { FuseLeveragedToken } from "@/utils/types";
 
-import { NavigationBar } from "@/components/NavigationBar";
-import { NavigationBarBottom } from "@/components/NavigationBarBottom";
+import NavigationBar from "@/components/NavigationBar";
+import NavigationBarBottom from "@/components/NavigationBarBottom";
 import BackgroundGradient from "@/components/BackgroundGradient";
-import { TradeInfoCard } from "@/components/TradeInfoCard";
-import { FuseLeveragedTokenInfoCard } from "@/components/FuseLeveragedTokenInfoCard";
+import TradeInfoCard from "@/components/TradeInfoCard";
+import FuseLeveragedTokenInfoCard from "@/components/FuseLeveragedTokenInfoCard";
 import BackingCard from "@/components/BackingCard";
 import SwapHistoryCard from "@/components/SwapHistoryCard";
 import SwapCard from "@/components/SwapCard";

--- a/apps/interface/utils/fetchFuseLeveragedTokenBySymbol.ts
+++ b/apps/interface/utils/fetchFuseLeveragedTokenBySymbol.ts
@@ -86,7 +86,7 @@ interface FuseLeveragedTokenBySymbolResponse {
     flts: Array<FuseLeveragedToken>;
 }
 
-export async function fetchFuseLeveragedTokenBySymbol(
+async function fetchFuseLeveragedTokenBySymbol(
     symbol: string
 ): Promise<FuseLeveragedTokenBySymbolResponse> {
     const { graphEndpoint } = getBaseConfig();
@@ -95,3 +95,5 @@ export async function fetchFuseLeveragedTokenBySymbol(
         symbol: filter,
     });
 }
+
+export default fetchFuseLeveragedTokenBySymbol;

--- a/apps/interface/utils/fetchFuseLeveragedTokenSymbols.ts
+++ b/apps/interface/utils/fetchFuseLeveragedTokenSymbols.ts
@@ -22,7 +22,9 @@ export interface FuseLeveragedTokenSymbols {
     flts: Array<{ symbol: string }>;
 }
 
-export async function fetchFuseLeveragedTokenSymbols(): Promise<FuseLeveragedTokenSymbols> {
+async function fetchFuseLeveragedTokenSymbols(): Promise<FuseLeveragedTokenSymbols> {
     const { graphEndpoint } = getBaseConfig();
     return await grequest(graphEndpoint, queryFuseLeveragedTokenSymbols);
 }
+
+export default fetchFuseLeveragedTokenSymbols;


### PR DESCRIPTION
## Scope
List of affected projects:

- apps/interface

## Description
We need to use default import for all imported components and utilities in [TradePage][1].

[1]: https://github.com/risedle/monorepo/blob/main/apps/interface/pages/trade/%5Bsymbol%5D.tsx#L5-L18

## Action items
Action items for this pull request:

- [x] Update `import {x} from "y"` to `import x from y`

## Checklist
You should check this before requesting for review:

- [x] Branch name use the the following format RIS-{NUMBER}
- [x] Pull request title is "chore(apps/interface): refactor TradePage imports"
- [x] Make sure new files are 100% covered in [Risedle Code Coverage](https://coverage.risedle.com)