### PR TITLE
chore(apps/interface): refactor IndexPage imports

### DIFF
--- a/apps/interface/components/FooterBar/index.tsx
+++ b/apps/interface/components/FooterBar/index.tsx
@@ -128,3 +128,5 @@ export const FooterBar = () => {
         </Container>
     );
 };
+
+export default FooterBar;

--- a/apps/interface/components/FooterBar/index.tsx
+++ b/apps/interface/components/FooterBar/index.tsx
@@ -12,7 +12,7 @@ import NextLink from "next/link";
 // Icons
 import ArrowTopRightIcon from "@/components/Icons/ArrowTopRight";
 
-export const FooterBar = () => {
+const FooterBar = () => {
     // Styles
     const gray3 = useColorModeValue("gray.light.3", "gray.dark.3");
     const gray10 = useColorModeValue("gray.light.10", "gray.dark.10");

--- a/apps/interface/components/HomeHeading/index.tsx
+++ b/apps/interface/components/HomeHeading/index.tsx
@@ -16,7 +16,7 @@ interface HomeHeadingProps {
     totalVolume: number;
 }
 
-export const HomeHeading = (props: HomeHeadingProps) => {
+const HomeHeading = (props: HomeHeadingProps) => {
     // Data
     const { totalMarketCap, totalVolume } = props;
 

--- a/apps/interface/components/HomeHeading/index.tsx
+++ b/apps/interface/components/HomeHeading/index.tsx
@@ -111,3 +111,5 @@ export const HomeHeading = (props: HomeHeadingProps) => {
         </Container>
     );
 };
+
+export default HomeHeading;

--- a/apps/interface/components/TokenCard/cards.tsx
+++ b/apps/interface/components/TokenCard/cards.tsx
@@ -26,3 +26,5 @@ export const TokenCards = (props: TokenCardsProps) => {
         </Container>
     );
 };
+
+export default TokenCards;

--- a/apps/interface/components/TokenCard/cards.tsx
+++ b/apps/interface/components/TokenCard/cards.tsx
@@ -6,7 +6,7 @@ import { TokenCard } from "./index";
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface TokenCardsProps extends FuseLeveragedTokens {}
 
-export const TokenCards = (props: TokenCardsProps) => {
+const TokenCards = (props: TokenCardsProps) => {
     // Data
     const { tokens } = props;
     const cards = tokens.map((token) => (

--- a/apps/interface/components/WarningBar/index.tsx
+++ b/apps/interface/components/WarningBar/index.tsx
@@ -110,3 +110,5 @@ export const WarningBar = () => {
         </Container>
     );
 };
+
+export default WarningBar;

--- a/apps/interface/pages/index.tsx
+++ b/apps/interface/pages/index.tsx
@@ -1,16 +1,24 @@
 import type { NextPage, GetStaticProps } from "next";
 import { NextSeo } from "next-seo";
 
-import { getBaseConfig } from "@/utils/getBaseConfig";
-import { fetchFuseLeveragedTokens } from "@/utils/fetchFuseLeveragedTokens";
+import getBaseConfig from "@/utils/getBaseConfig";
+import fetchFuseLeveragedTokens from "@/utils/fetchFuseLeveragedTokens";
 import type { FuseLeveragedTokens } from "@/utils/types";
-import { getFuseLeveragedTokensSummary } from "@/utils/getFuseLeveragedTokensSummary";
+import getFuseLeveragedTokensSummary from "@/utils/getFuseLeveragedTokensSummary";
 
+<<<<<<< HEAD
 import { WarningBar } from "@/components/WarningBar";
 import { NavigationBar } from "@/components/NavigationBar";
 import { HomeHeading } from "@/components/HomeHeading";
 import { TokenCards } from "@/components/TokenCard/cards";
 import { FooterBar } from "@/components/FooterBar";
+=======
+import WarningBar from "@/components/WarningBar";
+import NavigationBar from "@/components/NavigationBar";
+import HomeHeading from "@/components/HomeHeading";
+import TokenCards from "@/components/TokenCard/cards";
+import FooterBar from "@/components/FooterBar";
+>>>>>>> 07f13e0 (chore(apps/interface): refactor IndexPage imports)
 import NavigationBarBottom from "@/components/NavigationBarBottom";
 import BackgroundGradient from "@/components/BackgroundGradient";
 

--- a/apps/interface/pages/index.tsx
+++ b/apps/interface/pages/index.tsx
@@ -6,19 +6,11 @@ import fetchFuseLeveragedTokens from "@/utils/fetchFuseLeveragedTokens";
 import type { FuseLeveragedTokens } from "@/utils/types";
 import getFuseLeveragedTokensSummary from "@/utils/getFuseLeveragedTokensSummary";
 
-<<<<<<< HEAD
-import { WarningBar } from "@/components/WarningBar";
-import { NavigationBar } from "@/components/NavigationBar";
-import { HomeHeading } from "@/components/HomeHeading";
-import { TokenCards } from "@/components/TokenCard/cards";
-import { FooterBar } from "@/components/FooterBar";
-=======
 import WarningBar from "@/components/WarningBar";
 import NavigationBar from "@/components/NavigationBar";
 import HomeHeading from "@/components/HomeHeading";
 import TokenCards from "@/components/TokenCard/cards";
 import FooterBar from "@/components/FooterBar";
->>>>>>> 07f13e0 (chore(apps/interface): refactor IndexPage imports)
 import NavigationBarBottom from "@/components/NavigationBarBottom";
 import BackgroundGradient from "@/components/BackgroundGradient";
 

--- a/apps/interface/pages/shareable.tsx
+++ b/apps/interface/pages/shareable.tsx
@@ -1,6 +1,6 @@
 import type { NextPage } from "next";
 import { NavigationBar } from "@/components/NavigationBar";
-import { FooterBar } from "@/components/FooterBar";
+import FooterBar from "@/components/FooterBar";
 import InsightGenerator from "@/components/InsightGenerator";
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface

--- a/apps/interface/tests/components/FooterBar.spec.tsx
+++ b/apps/interface/tests/components/FooterBar.spec.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 
-import { FooterBar } from "@/components/FooterBar";
+import FooterBar from "@/components/FooterBar";
 
 describe("<FooterBar />", () => {
     it("should render links correctly", () => {

--- a/apps/interface/tests/components/TokenCards.spec.tsx
+++ b/apps/interface/tests/components/TokenCards.spec.tsx
@@ -2,7 +2,7 @@ import "@testing-library/jest-dom/extend-expect";
 import { render, screen } from "@testing-library/react";
 
 import "../utils/window.ResizeObserver.mock.ts";
-import { TokenCards } from "@/components/TokenCard/cards";
+import TokenCards from "@/components/TokenCard/cards";
 
 describe("<TokenCards />", () => {
     it("should render n number of <TokenCard />", () => {

--- a/apps/interface/tests/utils/getFuseLeveragedTokensSummary.spec.ts
+++ b/apps/interface/tests/utils/getFuseLeveragedTokensSummary.spec.ts
@@ -1,4 +1,4 @@
-import { getFuseLeveragedTokensSummary } from "@/utils/getFuseLeveragedTokensSummary";
+import getFuseLeveragedTokensSummary from "@/utils/getFuseLeveragedTokensSummary";
 
 describe("getFuseLeveragedTokensSummary", () => {
     it("should return summary", () => {

--- a/apps/interface/utils/fetchFuseLeveragedTokens.ts
+++ b/apps/interface/utils/fetchFuseLeveragedTokens.ts
@@ -74,10 +74,9 @@ const queryFuseLeveragedTokens = gql`
     }
 `;
 
-export const fetchFuseLeveragedTokens =
-    async (): Promise<FuseLeveragedTokens> => {
-        const { graphEndpoint } = getBaseConfig();
-        return await grequest(graphEndpoint, queryFuseLeveragedTokens);
-    };
+const fetchFuseLeveragedTokens = async (): Promise<FuseLeveragedTokens> => {
+    const { graphEndpoint } = getBaseConfig();
+    return await grequest(graphEndpoint, queryFuseLeveragedTokens);
+};
 
 export default fetchFuseLeveragedTokens;

--- a/apps/interface/utils/fetchFuseLeveragedTokens.ts
+++ b/apps/interface/utils/fetchFuseLeveragedTokens.ts
@@ -79,3 +79,5 @@ export const fetchFuseLeveragedTokens =
         const { graphEndpoint } = getBaseConfig();
         return await grequest(graphEndpoint, queryFuseLeveragedTokens);
     };
+
+export default fetchFuseLeveragedTokens;

--- a/apps/interface/utils/getFuseLeveragedTokensSummary.ts
+++ b/apps/interface/utils/getFuseLeveragedTokensSummary.ts
@@ -5,7 +5,7 @@ interface FuseLeveragedTokensSummary {
     totalVolume: number;
 }
 
-export const getFuseLeveragedTokensSummary = (
+const getFuseLeveragedTokensSummary = (
     data: FuseLeveragedTokens
 ): FuseLeveragedTokensSummary => {
     const initial = { totalMarketCap: 0, totalVolume: 0 };

--- a/apps/interface/utils/getFuseLeveragedTokensSummary.ts
+++ b/apps/interface/utils/getFuseLeveragedTokensSummary.ts
@@ -20,3 +20,4 @@ export const getFuseLeveragedTokensSummary = (
         };
     }, initial);
 };
+export default getFuseLeveragedTokensSummary;


### PR DESCRIPTION
Copy paste the following markdown in the pull request

## Scope
List of affected projects:

- apps/interface

## Description
We need to use default import for all imported components and utilities in [IndePage][1].

[1]: https://github.com/risedle/monorepo/blob/main/apps/interface/pages/index.tsx#L4-L15

## Action items
Action items for this pull request:

- [X] Update `import {x} from "y"` to `import x from y`

## Checklist
You should check this before requesting for review:

- [X] Branch name use the the following format RIS-{NUMBER}
- [X] Pull request title is "chore(apps/interface): refactor IndexPage imports"
- [X] Make sure new files are 100% covered in [Risedle Code Coverage](https://coverage.risedle.com)

