### PR TITLE
chore(apps/interface): refactor BackingCard AllocationTable

### DIFF
--- a/apps/interface/components/BackingCard/AllocationTable.tsx
+++ b/apps/interface/components/BackingCard/AllocationTable.tsx
@@ -141,7 +141,7 @@ const BackingCardAllocationTable = (
                 </Thead>
                 <Tbody>
                     <Tr>
-                        <Td borderColor={gray5} borderStyle="dashed">
+                        <Td borderColor={gray5} borderStyle="dashed" px="0">
                             <HStack w="100%">
                                 <Text
                                     color={gray12}

--- a/apps/interface/components/BackingCard/AllocationTable.tsx
+++ b/apps/interface/components/BackingCard/AllocationTable.tsx
@@ -225,12 +225,7 @@ const BackingCardAllocationTable = (
                         </Td>
                     </Tr>
                     <Tr>
-                        <Td
-                            borderColor={gray5}
-                            borderStyle="dashed"
-                            w="100%"
-                            px="0"
-                        >
+                        <Td border="none" w="100%" px="0">
                             <HStack w="100%">
                                 <Text
                                     color={gray12}
@@ -251,13 +246,7 @@ const BackingCardAllocationTable = (
                                 />
                             </HStack>
                         </Td>
-                        <Td
-                            pr="0px"
-                            borderColor={gray5}
-                            borderStyle="dashed"
-                            isNumeric
-                            px="2"
-                        >
+                        <Td pr="0px" border="none" isNumeric px="2">
                             <Skeleton
                                 isLoaded={isLoaded}
                                 startColor={gray3}
@@ -279,12 +268,7 @@ const BackingCardAllocationTable = (
                                 </Text>
                             </Skeleton>
                         </Td>
-                        <Td
-                            borderColor={gray5}
-                            borderStyle="dashed"
-                            isNumeric
-                            px="2"
-                        >
+                        <Td border="none" isNumeric px="2">
                             <Skeleton
                                 isLoaded={isLoaded}
                                 startColor={gray3}

--- a/apps/interface/components/BackingCard/AllocationTable.tsx
+++ b/apps/interface/components/BackingCard/AllocationTable.tsx
@@ -1,12 +1,15 @@
 import {
     BoxProps,
-    Flex,
-    VStack,
     HStack,
     useColorModeValue,
-    StackDivider,
     Text,
     Skeleton,
+    Table,
+    TableContainer,
+    Tbody,
+    Td,
+    Thead,
+    Tr,
 } from "@chakra-ui/react";
 
 // Utils
@@ -62,251 +65,223 @@ const BackingCardAllocationTable = (
     const debtChangeColor = debtChangePercent >= 0 ? green11 : red11;
 
     return (
-        <Flex
-            width="100%"
-            alignItems="flex-start"
-            margin="0 !important"
-            data-testid="BackingCardAllocationTable"
+        <TableContainer
+            w="100%"
             {...boxProps}
+            data-testid="BackingCardAllocationTable"
         >
-            {/* Asset */}
-            <VStack
-                flex="1"
-                alignItems="flex-start"
-                width="100%"
-                gap={4}
-                data-testid="AllocationTableAsset"
-            >
-                <Text
-                    padding="2"
-                    background={gray4}
-                    width="100%"
-                    borderTopLeftRadius="lg"
-                    borderBottomLeftRadius="lg"
-                    fontSize="xs"
-                    lineHeight="4"
-                    color={gray10}
-                >
-                    Asset
-                </Text>
-                <VStack
-                    divider={
-                        <StackDivider
+            <Table variant="simple">
+                <Thead>
+                    <Tr>
+                        <Td
                             borderColor={gray5}
-                            borderStyle="dashed"
-                            margin="0 !important"
-                        />
-                    }
-                    margin="0 !important"
-                    gap={4}
-                    width="100%"
-                    alignItems="flex-start"
-                >
-                    <HStack width="100%">
-                        <Text
-                            color={gray12}
-                            fontSize="sm"
-                            lineHeight="4"
-                            fontFamily="mono"
-                            fontWeight="semibold"
-                            paddingX="2"
-                            margin="0 !important"
-                            letterSpacing="tight"
-                            data-testid="BackingCardCollateral"
+                            px="0"
+                            data-testid="AllocationTableAsset"
                         >
-                            {collateralSymbol}
-                        </Text>
-                        <InfoTooltip
-                            info={`${collateralSymbol} used as collateral to borrow ${debtSymbol}`}
-                            color={gray10}
-                        />
-                    </HStack>
-                    <HStack width="100%">
-                        <Text
-                            color={gray12}
-                            fontSize="sm"
-                            lineHeight="4"
-                            fontFamily="mono"
-                            fontWeight="semibold"
-                            paddingX="2"
-                            margin="0 !important"
-                            letterSpacing="tight"
-                            data-testid="BackingCardDebt"
-                        >
-                            {debtSymbol}
-                        </Text>
-                        <InfoTooltip
-                            info={`${debtSymbol} is swapped to ${collateralSymbol}`}
-                            color={gray10}
-                        />
-                    </HStack>
-                </VStack>
-            </VStack>
-
-            {/* Allocation */}
-            <VStack
-                alignItems="flex-end"
-                gap={4}
-                data-testid="AllocationTableAmount"
-            >
-                <Text
-                    padding="2"
-                    background={gray4}
-                    fontSize="xs"
-                    lineHeight="4"
-                    color={gray10}
-                    width="100%"
-                    textAlign="right"
-                >
-                    Allocation
-                </Text>
-                <VStack
-                    divider={
-                        <StackDivider
-                            borderColor={gray5}
-                            borderStyle="dashed"
-                            margin="0 !important"
-                        />
-                    }
-                    margin="0 !important"
-                    gap={4}
-                    width="100%"
-                    alignItems="flex-end"
-                >
-                    {/* Collateral amount */}
-                    <Skeleton
-                        isLoaded={isLoaded}
-                        startColor={gray3}
-                        endColor={gray4}
-                        borderRadius="lg"
-                        marginX="2"
-                        minW="60px"
-                    >
-                        <Text
-                            color={gray12}
-                            fontSize="sm"
-                            lineHeight="4"
-                            fontFamily="mono"
-                            fontWeight="semibold"
-                            letterSpacing="tight"
-                            data-testid="AllocationTableCollateralAmount"
-                        >
-                            +{formatTokenBalance(collateralAmount)}
-                        </Text>
-                    </Skeleton>
-
-                    {/* Debt amount */}
-                    <Skeleton
-                        isLoaded={isLoaded}
-                        startColor={gray3}
-                        endColor={gray4}
-                        borderRadius="lg"
-                        marginX="2"
-                        minW="60px"
-                    >
-                        <Text
-                            color={gray12}
-                            fontSize="sm"
-                            lineHeight="4"
-                            fontFamily="mono"
-                            fontWeight="semibold"
-                            letterSpacing="tight"
-                            data-testid="AllocationTableDebtAmount"
-                        >
-                            -{formatTokenBalance(debtAmount)}
-                        </Text>
-                    </Skeleton>
-                </VStack>
-            </VStack>
-
-            {/* Changes */}
-            <VStack
-                alignItems="flex-end"
-                gap={4}
-                data-testid="AllocationTableChange"
-                minW="100px"
-            >
-                <Text
-                    padding="2"
-                    background={gray4}
-                    width="100%"
-                    fontSize="xs"
-                    lineHeight="4"
-                    color={gray10}
-                    borderTopRightRadius="lg"
-                    borderBottomRightRadius="lg"
-                    textAlign="right"
-                >
-                    24h Change
-                </Text>
-                <VStack
-                    divider={
-                        <StackDivider
-                            borderColor={gray5}
-                            borderStyle="dashed"
-                            margin="0 !important"
-                        />
-                    }
-                    margin="0 !important"
-                    gap={4}
-                    width="100%"
-                >
-                    {/* Collateral changes */}
-                    <Skeleton
-                        isLoaded={isLoaded}
-                        startColor={gray3}
-                        endColor={gray4}
-                        borderRadius="lg"
-                        marginX="2"
-                        minW="60px"
-                    >
-                        <HStack
-                            color={collateralChangeColor}
-                            spacing="1"
-                            justifyContent="flex-end"
-                        >
-                            {collateralChangeIcon}
                             <Text
-                                fontSize="sm"
-                                fontWeight="semibold"
+                                background={gray4}
+                                padding="2"
+                                width="100%"
+                                borderTopLeftRadius="lg"
+                                borderBottomLeftRadius="lg"
+                                fontSize="xs"
                                 lineHeight="4"
-                                letterSpacing="tight"
-                                fontFamily="mono"
+                                color={gray10}
+                                fontWeight="500"
                             >
-                                {formatPercent(collateralChangePercent / 100)}
+                                Asset
                             </Text>
-                        </HStack>
-                    </Skeleton>
-
-                    {/* Debt change */}
-                    <Skeleton
-                        isLoaded={isLoaded}
-                        startColor={gray3}
-                        endColor={gray4}
-                        borderRadius="lg"
-                        marginX="2"
-                        minW="60px"
-                    >
-                        <HStack
-                            color={debtChangeColor}
-                            spacing="1"
-                            justifyContent="flex-end"
+                        </Td>
+                        <Td
+                            isNumeric
+                            px="0"
+                            data-testid="AllocationTableAmount"
                         >
-                            {debtChangeIcon}
                             <Text
-                                fontSize="sm"
-                                fontWeight="semibold"
+                                background={gray4}
+                                padding="2"
+                                fontSize="xs"
                                 lineHeight="4"
-                                letterSpacing="tight"
-                                fontFamily="mono"
+                                color={gray10}
+                                width="100%"
+                                textAlign="right"
+                                fontFamily="sans-serif"
+                                fontWeight="500"
                             >
-                                {formatPercent(debtChangePercent / 100)}
+                                Allocation
                             </Text>
-                        </HStack>
-                    </Skeleton>
-                </VStack>
-            </VStack>
-        </Flex>
+                        </Td>
+                        <Td px="0" data-testid="AllocationTableChange">
+                            <Text
+                                fontFamily="sans-serif"
+                                background={gray4}
+                                padding="2"
+                                width="100%"
+                                fontSize="xs"
+                                lineHeight="4"
+                                fontWeight="500"
+                                color={gray10}
+                                borderTopRightRadius="lg"
+                                borderBottomRightRadius="lg"
+                                textAlign="right"
+                            >
+                                24h Change
+                            </Text>
+                        </Td>
+                    </Tr>
+                </Thead>
+                <Tbody>
+                    <Tr>
+                        <Td borderColor={gray5} px="2">
+                            <HStack w="100%">
+                                <Text
+                                    color={gray12}
+                                    fontSize="sm"
+                                    lineHeight="4"
+                                    fontFamily="mono"
+                                    fontWeight="semibold"
+                                    paddingX="2"
+                                    margin="0 !important"
+                                    letterSpacing="tight"
+                                    data-testid="BackingCardCollateral"
+                                >
+                                    {collateralSymbol}
+                                </Text>
+                                <InfoTooltip
+                                    info={`${debtSymbol} is swapped to ${collateralSymbol}`}
+                                    color={gray10}
+                                />
+                            </HStack>
+                        </Td>
+                        <Td isNumeric px="2">
+                            <Skeleton
+                                isLoaded={isLoaded}
+                                startColor={gray3}
+                                endColor={gray4}
+                                borderRadius="lg"
+                                marginX="2"
+                                minW="60px"
+                            >
+                                <Text
+                                    color={gray12}
+                                    fontSize="sm"
+                                    lineHeight="4"
+                                    fontFamily="mono"
+                                    fontWeight="semibold"
+                                    letterSpacing="tight"
+                                    data-testid="AllocationTableCollateralAmount"
+                                >
+                                    +{formatTokenBalance(collateralAmount)}
+                                </Text>
+                            </Skeleton>
+                        </Td>
+                        <Td isNumeric px="2">
+                            <Skeleton
+                                isLoaded={isLoaded}
+                                startColor={gray3}
+                                endColor={gray4}
+                                borderRadius="lg"
+                                marginX="2"
+                                minW="60px"
+                            >
+                                <HStack
+                                    color={collateralChangeColor}
+                                    spacing="1"
+                                    justifyContent="flex-end"
+                                >
+                                    {collateralChangeIcon}
+                                    <Text
+                                        fontSize="sm"
+                                        fontWeight="semibold"
+                                        lineHeight="4"
+                                        letterSpacing="tight"
+                                        fontFamily="mono"
+                                    >
+                                        {formatPercent(
+                                            collateralChangePercent / 100
+                                        )}
+                                    </Text>
+                                </HStack>
+                            </Skeleton>
+                        </Td>
+                    </Tr>
+                    <Tr>
+                        <Td borderColor={gray5} w="100%" px="2">
+                            <HStack w="100%">
+                                <Text
+                                    color={gray12}
+                                    fontSize="sm"
+                                    lineHeight="4"
+                                    fontFamily="mono"
+                                    fontWeight="semibold"
+                                    paddingX="2"
+                                    margin="0 !important"
+                                    letterSpacing="tight"
+                                    data-testid="BackingCardDebt"
+                                >
+                                    {debtSymbol}
+                                </Text>
+                                <InfoTooltip
+                                    info={`${debtSymbol} is swapped to ${collateralSymbol}`}
+                                    color={gray10}
+                                />
+                            </HStack>
+                        </Td>
+                        <Td isNumeric px="2">
+                            <Skeleton
+                                isLoaded={isLoaded}
+                                startColor={gray3}
+                                endColor={gray4}
+                                borderRadius="lg"
+                                marginX="2"
+                                minW="60px"
+                            >
+                                <Text
+                                    color={gray12}
+                                    fontSize="sm"
+                                    lineHeight="4"
+                                    fontFamily="mono"
+                                    fontWeight="semibold"
+                                    letterSpacing="tight"
+                                    data-testid="AllocationTableDebtAmount"
+                                >
+                                    -{formatTokenBalance(debtAmount)}
+                                </Text>
+                            </Skeleton>
+                        </Td>
+                        <Td isNumeric px="2">
+                            <Skeleton
+                                isLoaded={isLoaded}
+                                startColor={gray3}
+                                endColor={gray4}
+                                borderRadius="lg"
+                                marginX="2"
+                                minW="60px"
+                            >
+                                <HStack
+                                    color={debtChangeColor}
+                                    spacing="1"
+                                    justifyContent="flex-end"
+                                >
+                                    {debtChangeIcon}
+                                    <Text
+                                        fontSize="sm"
+                                        fontWeight="semibold"
+                                        lineHeight="4"
+                                        letterSpacing="tight"
+                                        fontFamily="mono"
+                                    >
+                                        {formatPercent(
+                                            debtChangePercent / 100
+                                        )}
+                                    </Text>
+                                </HStack>
+                            </Skeleton>
+                        </Td>
+                    </Tr>
+                </Tbody>
+            </Table>
+        </TableContainer>
     );
 };
 

--- a/apps/interface/components/BackingCard/AllocationTable.tsx
+++ b/apps/interface/components/BackingCard/AllocationTable.tsx
@@ -66,15 +66,17 @@ const BackingCardAllocationTable = (
 
     return (
         <TableContainer
+            mt="0px !important"
             w="100%"
             {...boxProps}
             data-testid="BackingCardAllocationTable"
         >
-            <Table variant="simple">
+            <Table mt="-16px !important" variant="simple">
                 <Thead>
                     <Tr>
                         <Td
-                            borderColor={gray5}
+                            border="none"
+                            pb="0px !important"
                             px="0"
                             data-testid="AllocationTableAsset"
                         >
@@ -93,6 +95,8 @@ const BackingCardAllocationTable = (
                             </Text>
                         </Td>
                         <Td
+                            pb="0px !important"
+                            border="none"
                             isNumeric
                             px="0"
                             data-testid="AllocationTableAmount"
@@ -111,7 +115,12 @@ const BackingCardAllocationTable = (
                                 Allocation
                             </Text>
                         </Td>
-                        <Td px="0" data-testid="AllocationTableChange">
+                        <Td
+                            pb="0px !important"
+                            border="none"
+                            px="0"
+                            data-testid="AllocationTableChange"
+                        >
                             <Text
                                 fontFamily="sans-serif"
                                 background={gray4}
@@ -132,7 +141,7 @@ const BackingCardAllocationTable = (
                 </Thead>
                 <Tbody>
                     <Tr>
-                        <Td borderColor={gray5} px="2">
+                        <Td borderColor={gray5} borderStyle="dashed">
                             <HStack w="100%">
                                 <Text
                                     color={gray12}
@@ -153,7 +162,12 @@ const BackingCardAllocationTable = (
                                 />
                             </HStack>
                         </Td>
-                        <Td isNumeric px="2">
+                        <Td
+                            borderColor={gray5}
+                            borderStyle="dashed"
+                            isNumeric
+                            pr="0px"
+                        >
                             <Skeleton
                                 isLoaded={isLoaded}
                                 startColor={gray3}
@@ -175,7 +189,12 @@ const BackingCardAllocationTable = (
                                 </Text>
                             </Skeleton>
                         </Td>
-                        <Td isNumeric px="2">
+                        <Td
+                            borderColor={gray5}
+                            borderStyle="dashed"
+                            isNumeric
+                            px="2"
+                        >
                             <Skeleton
                                 isLoaded={isLoaded}
                                 startColor={gray3}
@@ -206,7 +225,12 @@ const BackingCardAllocationTable = (
                         </Td>
                     </Tr>
                     <Tr>
-                        <Td borderColor={gray5} w="100%" px="2">
+                        <Td
+                            borderColor={gray5}
+                            borderStyle="dashed"
+                            w="100%"
+                            px="0"
+                        >
                             <HStack w="100%">
                                 <Text
                                     color={gray12}
@@ -227,7 +251,13 @@ const BackingCardAllocationTable = (
                                 />
                             </HStack>
                         </Td>
-                        <Td isNumeric px="2">
+                        <Td
+                            pr="0px"
+                            borderColor={gray5}
+                            borderStyle="dashed"
+                            isNumeric
+                            px="2"
+                        >
                             <Skeleton
                                 isLoaded={isLoaded}
                                 startColor={gray3}
@@ -249,7 +279,12 @@ const BackingCardAllocationTable = (
                                 </Text>
                             </Skeleton>
                         </Td>
-                        <Td isNumeric px="2">
+                        <Td
+                            borderColor={gray5}
+                            borderStyle="dashed"
+                            isNumeric
+                            px="2"
+                        >
                             <Skeleton
                                 isLoaded={isLoaded}
                                 startColor={gray3}


### PR DESCRIPTION

## Scope
List of affected projects:

- apps/interface

## Description
Currently the BackingCard [AllocationTable][1] is implemented as multiple VStack
stacked together.

We need to use Chakra `Table` component instead of using the div.

[1]: https://github.com/risedle/monorepo/blob/main/apps/interface/components/BackingCard/AllocationTable.tsx#L65

## Action items
Action items for this pull request:

- [X] Refactor the component to use `Table`
- [X] The generated component should spit out plain `<table>` element instead of div

## Checklist
You should check this before requesting for review:

- [X] Branch name use the the following format RIS-{NUMBER}
- [X] Pull request title is "chore(apps/interface): refactor BackingCard AllocationTable"
- [X] Make sure new files are 100% covered in [Risedle Code Coverage](https://coverage.risedle.com)

