### PR TITLE
chore(apps/interface): refactor ChevronUpIcon

### DIFF
--- a/apps/interface/components/Icons/ChevronUp.tsx
+++ b/apps/interface/components/Icons/ChevronUp.tsx
@@ -1,16 +1,14 @@
 import { IconProps, Icon } from "@chakra-ui/react";
 
-const ChevronUpIcon = (props: IconProps) => {
-    return (
-        <Icon viewBox="0 0 16 16" {...props}>
-            <path
-                fillRule="evenodd"
-                clipRule="evenodd"
-                d="M11.8648 9.34197C11.6759 9.54343 11.3595 9.55363 11.158 9.36477L7.5 5.93536L3.84197 9.36477C3.64051 9.55363 3.32409 9.54343 3.13523 9.34197C2.94636 9.14051 2.95657 8.82409 3.15803 8.63523L7.15803 4.88523C7.35036 4.70492 7.64964 4.70492 7.84197 4.88523L11.842 8.63523C12.0434 8.82409 12.0536 9.14051 11.8648 9.34197Z"
-                fill="currentColor"
-            />
-        </Icon>
-    );
-};
+const ChevronUpIcon = (props: IconProps) => (
+    <Icon viewBox="0 0 16 16" {...props}>
+        <path
+            fillRule="evenodd"
+            clipRule="evenodd"
+            d="M11.8648 9.34197C11.6759 9.54343 11.3595 9.55363 11.158 9.36477L7.5 5.93536L3.84197 9.36477C3.64051 9.55363 3.32409 9.54343 3.13523 9.34197C2.94636 9.14051 2.95657 8.82409 3.15803 8.63523L7.15803 4.88523C7.35036 4.70492 7.64964 4.70492 7.84197 4.88523L11.842 8.63523C12.0434 8.82409 12.0536 9.14051 11.8648 9.34197Z"
+            fill="currentColor"
+        />
+    </Icon>
+);
 
 export default ChevronUpIcon;


### PR DESCRIPTION
## Scope
List of affected projects:

- apps/interface

## Description
We need to refactor the `ChevronUpIcon` component.

Return `Icon` directly instead of using `return` keyword.

Update this:

```
const ChevronUpIcon = (props: IconProps) => {
	return <Icon />
}
```

to this:

```
const ChevronUpIcon = (props: IconProps) => (
	<Icon />
)
```


## Action items
Action items for this pull request:

- [x] Refactor the return function

## Checklist
You should check this before requesting for review:

- [x] Branch name use the the following format RIS-{NUMBER}
- [x] Pull request title is "chore(apps/interface): refactor ChevronUpIcon"
- [x] Make sure CSS styling is same as the spec (padding, border etc)
- [x] Make sure new files are 100% covered in [Risedle Code Coverage](https://coverage.risedle.com)