### PR TITLE
chore(apps/interface): refactor RedIndicatorIcon

### DIFF
--- a/apps/interface/components/Icons/RedIndicator.tsx
+++ b/apps/interface/components/Icons/RedIndicator.tsx
@@ -1,55 +1,53 @@
 import { Icon, IconProps } from "@chakra-ui/react";
 
-const RedIndicatorIcon = (props: IconProps) => {
-    return (
-        <Icon
-            data-testid="RedIndicatorIcon"
-            viewBox="0 0 32 32"
-            color="red.dark.10"
-            {...props}
-        >
-            <g filter="url(#filter0_d_3427_171249)">
-                <circle cx="16" cy="16.5" r="4" fill="currentColor" />
-            </g>
-            <defs>
-                <filter
-                    id="filter0_d_3427_171249"
-                    x="0"
-                    y="0.5"
-                    width="32"
-                    height="32"
-                    filterUnits="userSpaceOnUse"
-                    colorInterpolationFilters="sRGB"
-                >
-                    <feFlood floodOpacity="0" result="BackgroundImageFix" />
-                    <feColorMatrix
-                        in="SourceAlpha"
-                        type="matrix"
-                        values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
-                        result="hardAlpha"
-                    />
-                    <feOffset />
-                    <feGaussianBlur stdDeviation="6" />
-                    <feComposite in2="hardAlpha" operator="out" />
-                    <feColorMatrix
-                        type="matrix"
-                        values="0 0 0 0 0.94902 0 0 0 0 0.333333 0 0 0 0 0.352941 0 0 0 1 0"
-                    />
-                    <feBlend
-                        mode="normal"
-                        in2="BackgroundImageFix"
-                        result="effect1_dropShadow_3427_171249"
-                    />
-                    <feBlend
-                        mode="normal"
-                        in="SourceGraphic"
-                        in2="effect1_dropShadow_3427_171249"
-                        result="shape"
-                    />
-                </filter>
-            </defs>
-        </Icon>
-    );
-};
+const RedIndicatorIcon = (props: IconProps) => (
+    <Icon
+        data-testid="RedIndicatorIcon"
+        viewBox="0 0 32 32"
+        color="red.dark.10"
+        {...props}
+    >
+        <g filter="url(#filter0_d_3427_171249)">
+            <circle cx="16" cy="16.5" r="4" fill="currentColor" />
+        </g>
+        <defs>
+            <filter
+                id="filter0_d_3427_171249"
+                x="0"
+                y="0.5"
+                width="32"
+                height="32"
+                filterUnits="userSpaceOnUse"
+                colorInterpolationFilters="sRGB"
+            >
+                <feFlood floodOpacity="0" result="BackgroundImageFix" />
+                <feColorMatrix
+                    in="SourceAlpha"
+                    type="matrix"
+                    values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+                    result="hardAlpha"
+                />
+                <feOffset />
+                <feGaussianBlur stdDeviation="6" />
+                <feComposite in2="hardAlpha" operator="out" />
+                <feColorMatrix
+                    type="matrix"
+                    values="0 0 0 0 0.94902 0 0 0 0 0.333333 0 0 0 0 0.352941 0 0 0 1 0"
+                />
+                <feBlend
+                    mode="normal"
+                    in2="BackgroundImageFix"
+                    result="effect1_dropShadow_3427_171249"
+                />
+                <feBlend
+                    mode="normal"
+                    in="SourceGraphic"
+                    in2="effect1_dropShadow_3427_171249"
+                    result="shape"
+                />
+            </filter>
+        </defs>
+    </Icon>
+);
 
 export default RedIndicatorIcon;


### PR DESCRIPTION
## Scope
List of affected projects:

- apps/interface

## Description
We need to refactor the `RedIndicatorIcon` component.

Return `Icon` directly instead of using `return` keyword.

Update this:

```
const RedIndicatorIcon = (props: IconProps) => {
	return <Icon />
}
```

to this:

```
const RedIndicatorIcon = (props: IconProps) => (
	<Icon />
)
```


## Action items
Action items for this pull request:

- [x] Refactor the return function

## Checklist
You should check this before requesting for review:

- [x] Branch name use the the following format RIS-{NUMBER}
- [x] Pull request title is "chore(apps/interface): refactor RedIndicatorIcon"
- [x] Make sure CSS styling is same as the spec (padding, border etc)
- [x] Make sure new files are 100% covered in [Risedle Code Coverage](https://coverage.risedle.com)