### PR TITLE
chore(apps/interface): add concurrency flag to workflow

### DIFF
--- a/.github/workflows/apps-interface-prod.yml
+++ b/.github/workflows/apps-interface-prod.yml
@@ -60,3 +60,5 @@ jobs:
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
         run: flyctl deploy --remote-only --app risedle-interface-bsc
+
+concurrency: interface

--- a/.github/workflows/apps-interface-prod.yml
+++ b/.github/workflows/apps-interface-prod.yml
@@ -1,4 +1,5 @@
 name: "apps / interface / production"
+concurrency: interface
 
 on:
   push:
@@ -60,5 +61,3 @@ jobs:
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
         run: flyctl deploy --remote-only --app risedle-interface-bsc
-
-concurrency: interface

--- a/.github/workflows/apps-interface-stats.yml
+++ b/.github/workflows/apps-interface-stats.yml
@@ -1,4 +1,5 @@
 name: "apps / interface / stats"
+concurrency: interface
 
 on:
   pull_request:
@@ -116,5 +117,3 @@ jobs:
           body: ${{ steps.get-comment-body.outputs.body }}
           comment-id: ${{ steps.fc.outputs.comment-id }}
           edit-mode: replace
-
-concurrency: interface

--- a/.github/workflows/apps-interface-stats.yml
+++ b/.github/workflows/apps-interface-stats.yml
@@ -116,3 +116,5 @@ jobs:
           body: ${{ steps.get-comment-body.outputs.body }}
           comment-id: ${{ steps.fc.outputs.comment-id }}
           edit-mode: replace
+
+concurrency: interface


### PR DESCRIPTION
## Scope
List of affected projects:

- apps/interface

## Description
We want to be able to merge apps/interface change to main branch without
waiting the deployment finished.

In order to do that, we need to add concurrency in the `apps-interface-stag.yml`
and `apps-interface-prod.yml` github workflow.

```yaml
concurrency: interface
```

## Action items
Action items for this pull request:

- [x] Add `concurrency` to `apps-interface-stag.yml`
- [x] Add `concurrency` to `apps-interface-prod.yml`

## Checklist
You should check this before requesting for review:

- [x] Branch name use the the following format RIS-{NUMBER}
- [x] Pull request title is "chore(apps/interface): add concurrency flag to workflow"
- [x] Make sure new files are 100% covered in [Risedle Code Coverage](https://coverage.risedle.com)