### PR TITLE
feat(apps/interface): initialize Edge-rendered React app

### DIFF
--- a/apps/interface/README.md
+++ b/apps/interface/README.md
@@ -16,8 +16,12 @@ pnpm install
 Once all dependencies are installed, you can run local development server using
 the following command:
 
-```shell
+```bash
+# Interface V1
 pnpm dev
+
+# Interface V2
+pnpm exchange:dev
 ```
 
 There are some scripts that you can use for development:
@@ -28,6 +32,9 @@ pnpm prettier
 
 # To check code best practice
 pnpm lint
+
+# To validate Interface V2 code
+pnpm exchange:type
 ```
 
 If you setup git hooks via running `pnpm install` on monorepo root, you don't
@@ -45,7 +52,22 @@ To run individual spec file, use the following command:
 pnpm jest /path/to/file.spec.ts
 ```
 
-### Table of contents
+### Risedle Exchange
+
+Risedle Exchange is a codename for Risedle Interface V2. Risedle will
+transforms from leveraged token trading platform to cross-chain DeFi platform.
+
+Risedle Exchange will built on top of Edge-rendered React Application.
+Edge-rendered React apps is a React app that rendered in the Cloudflare
+Workers.
+
+Risedle Exchange will have the following notable features:
+
+-   Just-in-time rendering on the edge.
+-   Partial based client hydration for maximum interactivity.
+-   Zero runtime overhead. no JS is shipped to the client by default.
+
+### Table of contents (V1)
 
 -   [Data Fetching Strategy](#data-fetching-strategy)
 -   [Known Issues](#known-issues)

--- a/apps/interface/app/layout.tsx
+++ b/apps/interface/app/layout.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+const Layout = () => (
+    <html>
+        <head>
+            <title>Layout</title>
+        </head>
+        <body>200 OK</body>
+    </html>
+);
+
+export default Layout;

--- a/apps/interface/controller/home.ts
+++ b/apps/interface/controller/home.ts
@@ -1,0 +1,18 @@
+import React from "react";
+import { renderToReadableStream } from "react-dom/server";
+
+import { Env } from "@/env";
+import Layout from "@/app/layout";
+
+// TODO: implement cache here
+const GetHomePage = async (
+    req: Request,
+    env: Env,
+    ctx: ExecutionContext
+): Promise<Response> => {
+    const element = React.createElement(Layout);
+    const stream = await renderToReadableStream(element);
+    return new Response(stream);
+};
+
+export default GetHomePage;

--- a/apps/interface/controller/index.ts
+++ b/apps/interface/controller/index.ts
@@ -1,0 +1,5 @@
+import { Env } from "@/env";
+
+export interface Controller {
+    (req: Request, env: Env, ctx: ExecutionContext): Promise<Response>;
+}

--- a/apps/interface/entrypoint.server.ts
+++ b/apps/interface/entrypoint.server.ts
@@ -1,0 +1,13 @@
+import { Env } from "@/env";
+
+import router from "@/router";
+
+export default {
+    async fetch(
+        request: Request,
+        env: Env,
+        ctx: ExecutionContext
+    ): Promise<Response> {
+        return await router(request, env, ctx);
+    },
+};

--- a/apps/interface/env.ts
+++ b/apps/interface/env.ts
@@ -1,0 +1,10 @@
+/**
+ * When deploying a Module Worker, any bindings will not be available as
+ * global runtime variables. Instead, they are passed to the handler as a
+ * parameter.
+ *
+ * This Env interface define list of available binding.
+ *
+ * Docs: https://developers.cloudflare.com/workers/platform/environment-variables/
+ */
+export interface Env {}

--- a/apps/interface/package.json
+++ b/apps/interface/package.json
@@ -9,7 +9,9 @@
         "start": "next start",
         "lint": "next lint",
         "test": "jest",
-        "test:ci": "CI=true jest --reporters=default --reporters=github-actions"
+        "test:ci": "CI=true jest --reporters=default --reporters=github-actions",
+        "exchange:dev": "wrangler dev --local",
+        "exchange:type": "tsc -p tsconfig.exchange.json"
     },
     "prettier": "@risedle/prettier-config",
     "dependencies": {
@@ -39,6 +41,7 @@
         "zustand": "4.0.0"
     },
     "devDependencies": {
+        "@cloudflare/workers-types": "3.16.0",
         "@next/bundle-analyzer": "12.2.2",
         "@risedle/eslint-config": "0.1.2",
         "@risedle/prettier-config": "0.1.2",
@@ -62,7 +65,8 @@
         "prettier": "2.7.1",
         "ts-jest": "28.0.8",
         "ts-node": "10.9.1",
-        "typescript": "4.8.3"
+        "typescript": "4.8.3",
+        "wrangler": "2.1.9"
     },
     "nextBundleAnalysis": {
         "budget": 563200,

--- a/apps/interface/package.json
+++ b/apps/interface/package.json
@@ -11,7 +11,8 @@
         "test": "jest",
         "test:ci": "CI=true jest --reporters=default --reporters=github-actions",
         "exchange:dev": "wrangler dev --local",
-        "exchange:type": "tsc -p tsconfig.exchange.json"
+        "exchange:type": "tsc -p tsconfig.exchange.json",
+        "exchange:deploy": "wrangler publish"
     },
     "prettier": "@risedle/prettier-config",
     "dependencies": {

--- a/apps/interface/router/index.ts
+++ b/apps/interface/router/index.ts
@@ -1,0 +1,37 @@
+/**
+ * Router maps HTTP request to the controller
+ */
+import type { Env } from "@/env";
+import type { Controller } from "@/controller";
+// import GetHomePage from "@/controller/home";
+
+// get("/", GetHomePage);
+// get("/robots.txt", controller.GetRobotsText);
+// get("/assets/*", controller.GetStaticAssets);
+// use(controller.GetNotFoundPage);
+
+interface ControllerInfo {
+    method: "GET" | "POST";
+    handle: Controller;
+}
+const ControllerMap = new Map<URLPattern, ControllerInfo>();
+const get = (pattern: string, controller: Controller) => {
+    const compiledPattern = new URLPattern(pattern);
+    ControllerMap.set(compiledPattern, { method: "GET", handle: controller });
+};
+
+const router = async (
+    req: Request,
+    env: Env,
+    ctx: ExecutionContext
+): Promise<Response> => {
+    for (const [route, info] of ControllerMap) {
+        const result = route.exec(req.url);
+        if (result && req.method == info.method) {
+            return await info.handle(req, env, ctx);
+        }
+    }
+    return new Response("Controller not found", { status: 404 });
+};
+
+export default router;

--- a/apps/interface/tsconfig.exchange.json
+++ b/apps/interface/tsconfig.exchange.json
@@ -1,0 +1,40 @@
+{
+    "compilerOptions": {
+        /* Language and Environment */
+        "target": "es2021",
+        "lib": ["es2021"],
+        "jsx": "react",
+
+        /* Modules */
+        "module": "es2022",
+        "moduleResolution": "node",
+        "baseUrl": "./",
+        "paths": {
+            "@/*": ["*"]
+        },
+        "types": ["@cloudflare/workers-types"],
+        "resolveJsonModule": true,
+
+        /* JavaScript Support */
+        "allowJs": true,
+        "checkJs": true,
+
+        /* Emit */
+        "noEmit": true,
+
+        /* Interop Constraints */
+        "esModuleInterop": true,
+        "isolatedModules": true,
+        "forceConsistentCasingInFileNames": true,
+
+        /* Type Checking */
+        "strict": true
+    },
+    "include": [
+        "entrypoint.server.ts",
+        "app/**/*.tsx",
+        "route/**/*.ts",
+        "controller/**/*.ts"
+    ],
+    "exclude": ["node_modules"]
+}

--- a/apps/interface/tsconfig.json
+++ b/apps/interface/tsconfig.json
@@ -19,6 +19,6 @@
             "@/*": ["*"]
         }
     },
-    "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+    "include": ["next-env.d.ts", "pages/**/*.ts", "pages/**/*.tsx"],
     "exclude": ["node_modules"]
 }

--- a/apps/interface/wrangler.toml
+++ b/apps/interface/wrangler.toml
@@ -1,0 +1,8 @@
+name = "exchangee"
+main = "entrypoint.server.ts"
+compatibility_date = "2022-10-06"
+compatibility_flags = ["streams_enable_constructors"]
+tsconfig = "tsconfig.exchange.json"
+
+#[site]
+#bucket = "./public"

--- a/apps/interface/wrangler.toml
+++ b/apps/interface/wrangler.toml
@@ -1,6 +1,6 @@
-name = "exchangee"
+name = "exchange"
 main = "entrypoint.server.ts"
-compatibility_date = "2022-10-06"
+compatibility_date = "2022-10-03"
 compatibility_flags = ["streams_enable_constructors"]
 tsconfig = "tsconfig.exchange.json"
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,6 +124,7 @@ importers:
     specifiers:
       "@chakra-ui/react": 2.2.4
       "@chakra-ui/theme-tools": 2.0.11
+      "@cloudflare/workers-types": 3.16.0
       "@emotion/react": 11.9.3
       "@emotion/styled": 11.9.3
       "@fontsource/ibm-plex-mono": 4.5.10
@@ -169,6 +170,7 @@ importers:
       ts-node: 10.9.1
       typescript: 4.8.3
       wagmi: 0.6.0
+      wrangler: 2.1.9
       zustand: 4.0.0
     dependencies:
       "@chakra-ui/react": 2.2.4_lql7jgmwv7fr5m4p5jkjvvqrz4
@@ -196,6 +198,7 @@ importers:
       wagmi: 0.6.0_um4cugg2i3ywhvigsmvsir7hgy
       zustand: 4.0.0_react@18.2.0
     devDependencies:
+      "@cloudflare/workers-types": 3.16.0
       "@next/bundle-analyzer": 12.2.2
       "@risedle/eslint-config": 0.1.2
       "@risedle/prettier-config": 0.1.2
@@ -220,6 +223,7 @@ importers:
       ts-jest: 28.0.8_oavexkd2euoi6eueqpz7c42uqe
       ts-node: 10.9.1_tjxxr4okrdgzkzqzhfljhcr2hu
       typescript: 4.8.3
+      wrangler: 2.1.9
 
   apps/rebalancer:
     specifiers:
@@ -5949,6 +5953,13 @@ packages:
       mime: 3.0.0
     dev: true
 
+  /@cloudflare/workers-types/3.16.0:
+    resolution:
+      {
+        integrity: sha512-gaBUSaKS65mN3iKZEgichbXYEmAa/pXkc5Gbt+1BptYphdGkj09ggdsiE4w8g0F/uI1g36QaTKrzVnBAWMipvQ==,
+      }
+    dev: true
+
   /@cnakazawa/watch/1.0.4:
     resolution:
       {
@@ -8069,6 +8080,19 @@ packages:
       undici: 5.9.1
     dev: true
 
+  /@miniflare/cache/2.9.0:
+    resolution:
+      {
+        integrity: sha512-lriPxUEva9TJ01vU9P7pI60s3SsFnb4apWkNwZ+D7CRqyXPipSbapY8BWI2FUIwkEG7xap6UhzeTS76NettCXQ==,
+      }
+    engines: { node: ">=16.13" }
+    dependencies:
+      "@miniflare/core": 2.9.0
+      "@miniflare/shared": 2.9.0
+      http-cache-semantics: 4.1.0
+      undici: 5.9.1
+    dev: true
+
   /@miniflare/cli-parser/2.8.2:
     resolution:
       {
@@ -8077,6 +8101,17 @@ packages:
     engines: { node: ">=16.13" }
     dependencies:
       "@miniflare/shared": 2.8.2
+      kleur: 4.1.5
+    dev: true
+
+  /@miniflare/cli-parser/2.9.0:
+    resolution:
+      {
+        integrity: sha512-gu8Z7NWNcYw6514/yOvajaj3GmebRucx+EEt3p1vKirO+gvFgKAt/puyUN3p7u8ZZmLuLF/B+wVnH3lj8BWKlg==,
+      }
+    engines: { node: ">=16.13" }
+    dependencies:
+      "@miniflare/shared": 2.9.0
       kleur: 4.1.5
     dev: true
 
@@ -8099,6 +8134,36 @@ packages:
       urlpattern-polyfill: 4.0.3
     dev: true
 
+  /@miniflare/core/2.9.0:
+    resolution:
+      {
+        integrity: sha512-QqSwF6oHvgrFvN5lnrLc6EEagFlZWW+UMU8QdrE8305cNGHrIOxKCA2nte4PVFZUVw/Ts13a0tVhUk3a2fAyxQ==,
+      }
+    engines: { node: ">=16.13" }
+    dependencies:
+      "@iarna/toml": 2.2.5
+      "@miniflare/queues": 2.9.0
+      "@miniflare/shared": 2.9.0
+      "@miniflare/watcher": 2.9.0
+      busboy: 1.6.0
+      dotenv: 10.0.0
+      kleur: 4.1.5
+      set-cookie-parser: 2.5.1
+      undici: 5.9.1
+      urlpattern-polyfill: 4.0.3
+    dev: true
+
+  /@miniflare/d1/2.9.0:
+    resolution:
+      {
+        integrity: sha512-swK9nzxw1SvVh/4cH3bRR1SBuHQU/YsB8WvuHojxufmgviAD1xhms3XO3rkpAzfKoGM5Oy6DovMe0xUXV/GS0w==,
+      }
+    engines: { node: ">=16.7" }
+    dependencies:
+      "@miniflare/core": 2.9.0
+      "@miniflare/shared": 2.9.0
+    dev: true
+
   /@miniflare/durable-objects/2.8.2:
     resolution:
       {
@@ -8112,6 +8177,19 @@ packages:
       undici: 5.9.1
     dev: true
 
+  /@miniflare/durable-objects/2.9.0:
+    resolution:
+      {
+        integrity: sha512-7uTvfEUXS7xqwrsWOwWrFUuKc4EiMpVkAWPeYGLB/0TJaJ6N+sZMpYYymdW79TQwPIDfgtpfkIy93MRydqpnrw==,
+      }
+    engines: { node: ">=16.13" }
+    dependencies:
+      "@miniflare/core": 2.9.0
+      "@miniflare/shared": 2.9.0
+      "@miniflare/storage-memory": 2.9.0
+      undici: 5.9.1
+    dev: true
+
   /@miniflare/html-rewriter/2.8.2:
     resolution:
       {
@@ -8121,6 +8199,19 @@ packages:
     dependencies:
       "@miniflare/core": 2.8.2
       "@miniflare/shared": 2.8.2
+      html-rewriter-wasm: 0.4.1
+      undici: 5.9.1
+    dev: true
+
+  /@miniflare/html-rewriter/2.9.0:
+    resolution:
+      {
+        integrity: sha512-K5OB70PtkMo7M+tU46s/cX/j/qtjD9AlJ0hecYswrxVsfrT/YWyrCQJevmShFfJ92h7jPNigbeC3Od3JiVb6QA==,
+      }
+    engines: { node: ">=16.13" }
+    dependencies:
+      "@miniflare/core": 2.9.0
+      "@miniflare/shared": 2.9.0
       html-rewriter-wasm: 0.4.1
       undici: 5.9.1
     dev: true
@@ -8145,6 +8236,26 @@ packages:
       - utf-8-validate
     dev: true
 
+  /@miniflare/http-server/2.9.0:
+    resolution:
+      {
+        integrity: sha512-IVJMkFfMpecq9WiCTvATEKhMuKPK9fMs2E6zmgexaefr3u1VlNtj2QxBxoPUXkT9xMJQlT5sSKstlRR1XKDz9Q==,
+      }
+    engines: { node: ">=16.13" }
+    dependencies:
+      "@miniflare/core": 2.9.0
+      "@miniflare/shared": 2.9.0
+      "@miniflare/web-sockets": 2.9.0
+      kleur: 4.1.5
+      selfsigned: 2.1.1
+      undici: 5.9.1
+      ws: 8.8.1
+      youch: 2.2.2
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    dev: true
+
   /@miniflare/kv/2.8.2:
     resolution:
       {
@@ -8155,6 +8266,16 @@ packages:
       "@miniflare/shared": 2.8.2
     dev: true
 
+  /@miniflare/kv/2.9.0:
+    resolution:
+      {
+        integrity: sha512-EqG51okY5rDtgjYs2Ny6j6IUVdTlJzDjwBKBIuW+wOV9NsAAzEchKVdYAXc8CyxvkggpYX481HydTD2OzK3INQ==,
+      }
+    engines: { node: ">=16.13" }
+    dependencies:
+      "@miniflare/shared": 2.9.0
+    dev: true
+
   /@miniflare/queues/2.8.2:
     resolution:
       {
@@ -8163,6 +8284,16 @@ packages:
     engines: { node: ">=16.7" }
     dependencies:
       "@miniflare/shared": 2.8.2
+    dev: true
+
+  /@miniflare/queues/2.9.0:
+    resolution:
+      {
+        integrity: sha512-cAHWIlLF57rxQaJl19AzXw1k0SOM/uLTlx8r2PylHajZ/RRSs7CkCox3oKA6E5zKyfyxk2M64bmsAFZ9RCA0gw==,
+      }
+    engines: { node: ">=16.7" }
+    dependencies:
+      "@miniflare/shared": 2.9.0
     dev: true
 
   /@miniflare/r2/2.8.2:
@@ -8176,6 +8307,17 @@ packages:
       undici: 5.9.1
     dev: true
 
+  /@miniflare/r2/2.9.0:
+    resolution:
+      {
+        integrity: sha512-aMFWxxciAE3YsVok2OLy3A7hP5+2j/NaK7txmadgoe1CA8HYZyNuvv7v6bn8HKM5gWnJdT8sk4yEbMbBQ7Jv/A==,
+      }
+    engines: { node: ">=16.13" }
+    dependencies:
+      "@miniflare/shared": 2.9.0
+      undici: 5.9.1
+    dev: true
+
   /@miniflare/runner-vm/2.8.2:
     resolution:
       {
@@ -8184,6 +8326,16 @@ packages:
     engines: { node: ">=16.13" }
     dependencies:
       "@miniflare/shared": 2.8.2
+    dev: true
+
+  /@miniflare/runner-vm/2.9.0:
+    resolution:
+      {
+        integrity: sha512-vewP+Fy7Czb261GmB9x/YtQkoDs/QP9B5LbP0YfJ35bI2C2j940eJLm8JP72IHV7ILtWNOqMc3Ure8uAbpf9NQ==,
+      }
+    engines: { node: ">=16.13" }
+    dependencies:
+      "@miniflare/shared": 2.9.0
     dev: true
 
   /@miniflare/scheduler/2.8.2:
@@ -8198,6 +8350,18 @@ packages:
       cron-schedule: 3.0.6
     dev: true
 
+  /@miniflare/scheduler/2.9.0:
+    resolution:
+      {
+        integrity: sha512-eodSCGkJYi4Z+Imbx/bNScDfDSt5HOypVSYjbFHj+hA2aNOdkGw6a1b6mzwx49jJD3GadIkonZAKD0S114yWMA==,
+      }
+    engines: { node: ">=16.13" }
+    dependencies:
+      "@miniflare/core": 2.9.0
+      "@miniflare/shared": 2.9.0
+      cron-schedule: 3.0.6
+    dev: true
+
   /@miniflare/shared/2.8.2:
     resolution:
       {
@@ -8206,6 +8370,19 @@ packages:
     engines: { node: ">=16.13" }
     dependencies:
       kleur: 4.1.5
+      picomatch: 2.3.1
+    dev: true
+
+  /@miniflare/shared/2.9.0:
+    resolution:
+      {
+        integrity: sha512-5Ew/Ph0cHDQqKvOlmN70kz+qZW0hdgE9fQBStKLY3vDYhnBEhopbCUChSS+FCcL7WtxVJJVE7iB6J09NQTnQ/A==,
+      }
+    engines: { node: ">=16.13" }
+    dependencies:
+      "@types/better-sqlite3": 7.6.0
+      kleur: 4.1.5
+      npx-import: 1.1.3
       picomatch: 2.3.1
     dev: true
 
@@ -8221,6 +8398,18 @@ packages:
       "@miniflare/storage-file": 2.8.2
     dev: true
 
+  /@miniflare/sites/2.9.0:
+    resolution:
+      {
+        integrity: sha512-+tWf7znxSQqXWGzPup8Xqkl8EmLmx+HaLC+UBtWPNnaJZrsjbbVxKwHpmGIdm+wZasEGfQk/82R21gUs9wdZnw==,
+      }
+    engines: { node: ">=16.13" }
+    dependencies:
+      "@miniflare/kv": 2.9.0
+      "@miniflare/shared": 2.9.0
+      "@miniflare/storage-file": 2.9.0
+    dev: true
+
   /@miniflare/storage-file/2.8.2:
     resolution:
       {
@@ -8230,6 +8419,17 @@ packages:
     dependencies:
       "@miniflare/shared": 2.8.2
       "@miniflare/storage-memory": 2.8.2
+    dev: true
+
+  /@miniflare/storage-file/2.9.0:
+    resolution:
+      {
+        integrity: sha512-HZHtHfJaLoDzQFddoIMcDGgAJ3/Nee98gwUYusQam7rj9pbEXnWmk54dzjzsDlkQpB/3MBFQNbtN5Bj1NIt0pg==,
+      }
+    engines: { node: ">=16.13" }
+    dependencies:
+      "@miniflare/shared": 2.9.0
+      "@miniflare/storage-memory": 2.9.0
     dev: true
 
   /@miniflare/storage-memory/2.8.2:
@@ -8242,6 +8442,16 @@ packages:
       "@miniflare/shared": 2.8.2
     dev: true
 
+  /@miniflare/storage-memory/2.9.0:
+    resolution:
+      {
+        integrity: sha512-p2yrr0omQhv6teDbdzhdBKzoQAFmUBMLEx+PtrO7CJHX15ICD08/pFAFAp96IcljNwZZDchU20Z3AcbldMj6Tw==,
+      }
+    engines: { node: ">=16.13" }
+    dependencies:
+      "@miniflare/shared": 2.9.0
+    dev: true
+
   /@miniflare/watcher/2.8.2:
     resolution:
       {
@@ -8250,6 +8460,16 @@ packages:
     engines: { node: ">=16.13" }
     dependencies:
       "@miniflare/shared": 2.8.2
+    dev: true
+
+  /@miniflare/watcher/2.9.0:
+    resolution:
+      {
+        integrity: sha512-Yqz8Q1He/2chebXvmCft8sMamuUiDQ4FIn0bwiF0+GBP2vvGCmy6SejXZY4ZD4REluPqQSis3CLKcIOWlHnIsw==,
+      }
+    engines: { node: ">=16.13" }
+    dependencies:
+      "@miniflare/shared": 2.9.0
     dev: true
 
   /@miniflare/web-sockets/2.8.2:
@@ -8261,6 +8481,22 @@ packages:
     dependencies:
       "@miniflare/core": 2.8.2
       "@miniflare/shared": 2.8.2
+      undici: 5.9.1
+      ws: 8.8.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    dev: true
+
+  /@miniflare/web-sockets/2.9.0:
+    resolution:
+      {
+        integrity: sha512-Nob9e84m78qeQCka6OQf/JdNOmMkKCkX+i3rg+TYKSSITiMVuyzWp3vz3Ma184lAZiLg44lxBF4ZzENEdi99Kg==,
+      }
+    engines: { node: ">=16.13" }
+    dependencies:
+      "@miniflare/core": 2.9.0
+      "@miniflare/shared": 2.9.0
       undici: 5.9.1
       ws: 8.8.1
     transitivePeerDependencies:
@@ -10879,6 +11115,15 @@ packages:
       }
     dependencies:
       "@babel/types": 7.19.0
+    dev: true
+
+  /@types/better-sqlite3/7.6.0:
+    resolution:
+      {
+        integrity: sha512-rnSP9vY+fVsF3iJja5yRGBJV63PNBiezJlYrCkqUmQWFoB16cxAHwOkjsAYEu317miOfKaJpa65cbp0P4XJ/jw==,
+      }
+    dependencies:
+      "@types/node": 18.7.18
     dev: true
 
   /@types/bn.js/4.11.6:
@@ -14601,6 +14846,15 @@ packages:
       {
         integrity: sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ==,
       }
+
+  /builtins/5.0.1:
+    resolution:
+      {
+        integrity: sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==,
+      }
+    dependencies:
+      semver: 7.3.7
+    dev: true
 
   /busboy/1.6.0:
     resolution:
@@ -22181,7 +22435,7 @@ packages:
       pretty-format: 28.1.3
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1_xtowvbsomha52a5oqacf7oijd4
+      ts-node: 10.9.1_tjxxr4okrdgzkzqzhfljhcr2hu
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -24288,6 +24542,51 @@ packages:
       - utf-8-validate
     dev: true
 
+  /miniflare/2.9.0:
+    resolution:
+      {
+        integrity: sha512-HBGQ5Jj6sMU1B1hX6G3ML46ThtUvu1nvxgXjDDmhp2RhWKYj0XvcohW/nPPL/MTP1gpvfT880De9EHmobVsDsw==,
+      }
+    engines: { node: ">=16.13" }
+    hasBin: true
+    peerDependencies:
+      "@miniflare/storage-redis": 2.9.0
+      cron-schedule: ^3.0.4
+      ioredis: ^4.27.9
+    peerDependenciesMeta:
+      "@miniflare/storage-redis":
+        optional: true
+      cron-schedule:
+        optional: true
+      ioredis:
+        optional: true
+    dependencies:
+      "@miniflare/cache": 2.9.0
+      "@miniflare/cli-parser": 2.9.0
+      "@miniflare/core": 2.9.0
+      "@miniflare/d1": 2.9.0
+      "@miniflare/durable-objects": 2.9.0
+      "@miniflare/html-rewriter": 2.9.0
+      "@miniflare/http-server": 2.9.0
+      "@miniflare/kv": 2.9.0
+      "@miniflare/queues": 2.9.0
+      "@miniflare/r2": 2.9.0
+      "@miniflare/runner-vm": 2.9.0
+      "@miniflare/scheduler": 2.9.0
+      "@miniflare/shared": 2.9.0
+      "@miniflare/sites": 2.9.0
+      "@miniflare/storage-file": 2.9.0
+      "@miniflare/storage-memory": 2.9.0
+      "@miniflare/web-sockets": 2.9.0
+      kleur: 4.1.5
+      semiver: 1.1.0
+      source-map-support: 0.5.21
+      undici: 5.9.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    dev: true
+
   /minimalistic-assert/1.0.1:
     resolution:
       {
@@ -25167,6 +25466,18 @@ packages:
       }
     dev: false
 
+  /npx-import/1.1.3:
+    resolution:
+      {
+        integrity: sha512-zy6249FJ81OtPsvz2y0+rgis31EN5wbdwBG2umtEh65W/4onYArHuoUSZ+W+T7BQYK7YF+h9G4CuGPusMCcLOw==,
+      }
+    dependencies:
+      execa: 6.1.0
+      parse-package-name: 1.0.0
+      semver: 7.3.7
+      validate-npm-package-name: 4.0.0
+    dev: true
+
   /nth-check/2.1.1:
     resolution:
       {
@@ -25787,6 +26098,13 @@ packages:
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
+
+  /parse-package-name/1.0.0:
+    resolution:
+      {
+        integrity: sha512-kBeTUtcj+SkyfaW4+KBe0HtsloBJ/mKTPoxpVdA57GZiPerREsUWJOhVj9anXweFiJkm5y8FG1sxFZkZ0SN6wg==,
+      }
+    dev: true
 
   /parse5-htmlparser2-tree-adapter/6.0.1:
     resolution:
@@ -31966,6 +32284,16 @@ packages:
       spdx-expression-parse: 3.0.1
     dev: true
 
+  /validate-npm-package-name/4.0.0:
+    resolution:
+      {
+        integrity: sha512-mzR0L8ZDktZjpX4OB46KT+56MAhl4EIazWP/+G/HPGuvfdaqg4YsCdtOm6U9+LOFyYDoh4dpnpxZRB9MQQns5Q==,
+      }
+    engines: { node: ^12.13.0 || ^14.15.0 || >=16.0.0 }
+    dependencies:
+      builtins: 5.0.1
+    dev: true
+
   /validator/13.7.0:
     resolution:
       {
@@ -32601,6 +32929,39 @@ packages:
       chokidar: 3.5.3
       esbuild: 0.14.51
       miniflare: 2.8.2
+      nanoid: 3.3.4
+      path-to-regexp: 6.2.1
+      selfsigned: 2.1.1
+      source-map: 0.7.4
+      xxhash-wasm: 1.0.1
+    optionalDependencies:
+      fsevents: 2.3.2
+    transitivePeerDependencies:
+      - "@miniflare/storage-redis"
+      - bufferutil
+      - cron-schedule
+      - ioredis
+      - utf-8-validate
+    dev: true
+
+  /wrangler/2.1.9:
+    resolution:
+      {
+        integrity: sha512-ryrkpUEqgJZIiGgo+VCUYtl0B+shEbyp3FZzT5+GYnyfpLtQutAZlS/s5iOC0qjZ7TcRzWS1PSb9fE9nDSvCKg==,
+      }
+    engines: { node: ">=16.13.0" }
+    hasBin: true
+    dependencies:
+      "@cloudflare/kv-asset-handler": 0.2.0
+      "@esbuild-plugins/node-globals-polyfill": 0.1.1_esbuild@0.14.51
+      "@esbuild-plugins/node-modules-polyfill": 0.1.4_esbuild@0.14.51
+      "@miniflare/core": 2.9.0
+      "@miniflare/d1": 2.9.0
+      "@miniflare/durable-objects": 2.9.0
+      blake3-wasm: 2.1.5
+      chokidar: 3.5.3
+      esbuild: 0.14.51
+      miniflare: 2.9.0
       nanoid: 3.3.4
       path-to-regexp: 6.2.1
       selfsigned: 2.1.1


### PR DESCRIPTION
## Scope
List of affected projects:

- apps/interface

## Description
Initialize edge-rendered React apps.

Edge-rendered React apps is a React app that rendered on the Cloudflare Workers.

To prepare our new Risedle Exchange, we need to build the following react apps:
- Just-in-time rendering on the edge.
- Partial based client hydration for maximum interactivity.
- Zero runtime overhead. no JS is shipped to the client by default.

We need to initialize the project. We need to add the following scripts:

```bash
# Run local development server
pnpm exchange:dev

# Check the types
pnpm exchange:type

# Deploy the edge-rendered react app
pnpm exchange:deploy
```

## Action items
Action items for this pull request:

- [x] Add `pnpm exchange:dev`
- [x] Add `pnpm exchange:type`
- [x] Add `pnpm exchange:deploy`
- [x] Update README

## Checklist
You should check this before requesting for review:

- [x] Branch name use the the following format RIS-{NUMBER}
- [x] Pull request title is "feat(apps/interface): initialize Edge-rendered React app"
- [x] Make sure CSS styling is same as the spec (padding, border etc)
- [x] Make sure new files are 100% covered in [Risedle Code Coverage](https://coverage.risedle.com)

