### PR TITLE
fix(apps/interface): rebalancer staging worklow

### DIFF
--- a/.github/workflows/apps-rebalancer-stag.yml
+++ b/.github/workflows/apps-rebalancer-stag.yml
@@ -7,7 +7,7 @@ on:
     paths:
       - "pnpm-lock.yaml"
       - "apps/rebalancer/**"
-      - ".github/workflows/apps-rebalancer.yml"
+      - ".github/workflows/apps-rebalancer-stag.yml"
 
 defaults:
   run:


### PR DESCRIPTION
## Scope
List of affected projects:

- apps/interface

## Description
There is invalid path in the `apps-rebalancer-stag.yml` https://github.com/risedle/monorepo/blob/d658b97f2d9b483038e9b5abe7bf1a5c5a834684/.github/workflows/apps-rebalancer-stag.yml#L10

This should be `/apps-rebalancer-stag.yml` instead of `/apps-rebalancer.yml`

## Action items
Action items for this pull request:

- [x] Fix `apps-rebalancer-stag.yml` workflow

## Checklist
You should check this before requesting for review:

- [x] Branch name use the the following format RIS-{NUMBER}
- [x] Pull request title is "fix(apps/interface): rebalancer staging worklow"
- [x] Make sure CSS styling is same as the spec (padding, border etc)
- [x] Make sure new files are 100% covered in [Risedle Code Coverage](https://coverage.risedle.com)