### PR TITLE
chore(apps/interface): refactor NavigationBarBottom

### DIFF
--- a/apps/interface/components/NavigationBarBottom/index.tsx
+++ b/apps/interface/components/NavigationBarBottom/index.tsx
@@ -2,7 +2,7 @@ import { Container, Flex, useColorModeValue } from "@chakra-ui/react";
 
 import ChainSwitcher from "../ChainSwitcher";
 import ConnectWalletButton from "../ConnectWalletButton";
-import { NavigationBarBottomLinks } from "./links";
+import NavigationBarBottomLinks from "./links";
 
 const NavigationBarBottom = () => {
     const gray2 = useColorModeValue("gray.light.2", "gray.dark.2");

--- a/apps/interface/components/NavigationBarBottom/links.tsx
+++ b/apps/interface/components/NavigationBarBottom/links.tsx
@@ -215,7 +215,7 @@ const LearnMoreLinks = () => {
     );
 };
 
-export const NavigationBarBottomLinks = (props: ButtonProps) => {
+const NavigationBarBottomLinks = (props: ButtonProps) => {
     // Styles
     const gray2 = useColorModeValue("gray.light.2", "gray.dark.2");
     const gray3 = useColorModeValue("gray.light.3", "gray.dark.3");
@@ -297,3 +297,5 @@ export const NavigationBarBottomLinks = (props: ButtonProps) => {
         </Menu>
     );
 };
+
+export default NavigationBarBottomLinks;

--- a/apps/interface/tests/components/NavigationBarBottomLinks.spec.tsx
+++ b/apps/interface/tests/components/NavigationBarBottomLinks.spec.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 
-import { NavigationBarBottomLinks } from "@/components/NavigationBarBottom/links";
+import NavigationBarBottomLinks from "@/components/NavigationBarBottom/links";
 
 describe("<NavigationBarBottomLink />", () => {
     describe("When not clicked", () => {


### PR DESCRIPTION
Copy paste the following markdown in the pull request

## Scope
List of affected projects:

- apps/interface

## Description
We need to refactor the `NavigationBarBottom` component.

First we need to use default import for all subcomponents:

```typescript
// this
import { NavigationBarBottomLinks } from "./links";

// to this
import NavigationBarBottomLinks from "./links";
```

We may also need to refactor all sub components to use default export.


## Action items
Action items for this pull request:

- [X] Use default import for all sub-components
- [X] Remove default export for NavigationBarBottom and all sub-components

## Checklist
You should check this before requesting for review:

- [X] Branch name use the the following format RIS-{NUMBER}
- [X] Pull request title is "chore(apps/interface): refactor NavigationBarBottom"
- [X] Make sure CSS styling is same as the spec (padding, border etc)
- [X] Make sure new files are 100% covered in [Risedle Code Coverage](https://coverage.risedle.com)