### PR TITLE
chore(apps/interface): increase coverage for InsightImageDOM

### DIFF
--- a/apps/interface/components/InsightImageDOM/index.tsx
+++ b/apps/interface/components/InsightImageDOM/index.tsx
@@ -73,7 +73,6 @@ const InsightImageDOM = React.forwardRef(
         }
 
         if (isLoaded && data) {
-            console.log(data);
             return (
                 <>
                     <div data-testid="InsightGeneratorDiv" ref={imageRef}>

--- a/apps/interface/components/InsightImageDOM/index.tsx
+++ b/apps/interface/components/InsightImageDOM/index.tsx
@@ -52,14 +52,14 @@ const InsightImageDOM = React.forwardRef(
 
         useImperativeHandle(ref, () => ({
             getImage() {
-                let timestamp = data?.[0].dailyGain.timestamp;
-                if (timestamp == undefined) {
-                    timestamp = Math.floor(Date.now() / 1000);
+                if (data) {
+                    const timestamp = data[0].dailyGain.timestamp;
+
+                    const filename = `${props.type} ${dayjs(
+                        timestamp * 1000
+                    ).format("DD-MM-YY")}.jpeg`;
+                    exportImage(imageRef.current, filename);
                 }
-                const filename = `${props.type} ${dayjs(
-                    timestamp * 1000
-                ).format("DD-MM-YY")}.jpeg`;
-                exportImage(imageRef.current, filename);
             },
         }));
 
@@ -73,6 +73,7 @@ const InsightImageDOM = React.forwardRef(
         }
 
         if (isLoaded && data) {
+            console.log(data);
             return (
                 <>
                     <div data-testid="InsightGeneratorDiv" ref={imageRef}>

--- a/apps/interface/tests/components/InsightImageDom.spec.tsx
+++ b/apps/interface/tests/components/InsightImageDom.spec.tsx
@@ -1,7 +1,9 @@
 import "@testing-library/jest-dom/extend-expect";
 import { render, screen } from "@testing-library/react";
-import InsightImageDOM from "@/components/InsightImageDOM";
+import InsightImageDOM, { exportImage } from "@/components/InsightImageDOM";
 import * as SWR from "swr";
+import React from "react";
+import domtoimage from "dom-to-image";
 
 afterEach(() => {
     // restore the spy created with spyOn
@@ -9,6 +11,40 @@ afterEach(() => {
 });
 
 describe("<InsightImageDOM />", () => {
+    describe("Test function", () => {
+        const { getComputedStyle } = window;
+        window.getComputedStyle = (elt) => getComputedStyle(elt);
+        jest.setTimeout(10000);
+        it("Should return download", async () => {
+            const div = document.createElement("div");
+            const link = {
+                click: jest.fn(),
+            };
+            jest.spyOn(document, "createElement").mockImplementation(
+                () => link
+            );
+            jest.spyOn(domtoimage, "toJpeg").mockImplementation(
+                (div) => "data:application/txt,hello%20world"
+            );
+
+            await exportImage(div, "test.jpeg");
+            expect(link.click).toHaveBeenCalledTimes(1);
+            expect(link.href).toEqual("data:application/txt,hello%20world");
+            expect(link.download).toEqual("test.jpeg");
+        });
+
+        it("Should return alert", async () => {
+            const div = document.createElement("div");
+            window.alert = jest.fn();
+
+            await exportImage(null, "test.jpeg");
+
+            const link = {
+                click: jest.fn(),
+            };
+            expect(window.alert).toHaveBeenCalledTimes(1);
+        });
+    });
     describe("Test Data", () => {
         it("should render loading", () => {
             const mock = jest.spyOn(SWR, "default");


### PR DESCRIPTION

## Scope
List of affected projects:

- apps/interface

## Description
We need to increase the test coverage for `components/InsightImageDOM/index.tsx`

See the recent coverage here https://coverage.risedle.com/apps/interface/coverage/lcov-report/components/InsightImageDOM/index.tsx.html

you will notice that the following function is not covered yet:

```typescript
// Given html element and filename, export html element to downloadble filename
export async function exportImage(
    element: HTMLElement | null,
    filename: string
): Promise<void> {
    if (element) {
        const result = await domtoimage.toJpeg(element);
        const link = document.createElement("a");
        link.className = "download-helper";
        link.download = filename;
        link.href = result;
        link.click();
    } else {
        alert("Element is null");
    }
}
```

and also `InsightImageDOM` is not rendered with `timestamp=undefined` yet on the test.

So we need to update https://github.com/risedle/monorepo/blob/main/apps/interface/tests/components/InsightImageDom.spec.tsx
to test `exportImage` with element defined and null.

Then we also need to render `InsightImageDOM` and mock `useGetInsight` to return dailyGain.timestamp as undefined.

## Action items
Action items for this pull request:

- [X] Add `exportImage` test to `InsightImageDOM` test 
- [X] Add case where `useGetInsight` returns undefined timestamp when render

## Checklist
You should check this before requesting for review:

- [X] Branch name use the the following format RIS-{NUMBER}
- [X] Pull request title is "chore(apps/interface): increase coverage for InsightImageDOM"
- [X] Make sure CSS styling is same as the spec (padding, border etc)
- [X] Make sure new files are 100% covered in [Risedle Code Coverage](https://coverage.risedle.com)

